### PR TITLE
Introduce SCMI server skeleton for RPI5

### DIFF
--- a/plat/rpi/common/rpi3_common.c
+++ b/plat/rpi/common/rpi3_common.c
@@ -50,6 +50,13 @@
 				MT_MEMORY | MT_RW | MT_SECURE)
 #endif
 
+#ifdef SCMI_SERVER_SUPPORT
+#define MAP_SCMI_MEM	MAP_REGION_FLAT(		\
+				RPI_SCMI_SHMEM_BASE,	\
+				RPI_SCMI_SHMEM_SIZE,	\
+				MT_NON_CACHEABLE | MT_RW | MT_NS)
+#endif
+
 /*
  * Table of regions for various BL stages to map using the MMU.
  */
@@ -93,6 +100,9 @@ static const mmap_region_t plat_rpi3_mmap[] = {
 #endif
 #ifdef BL32_BASE
 	MAP_BL32_MEM,
+#endif
+#ifdef SCMI_SERVER_SUPPORT
+	MAP_SCMI_MEM,
 #endif
 	{0}
 };

--- a/plat/rpi/rpi5/include/platform_def.h
+++ b/plat/rpi/rpi5/include/platform_def.h
@@ -118,7 +118,7 @@
 #define PLAT_VIRT_ADDR_SPACE_SIZE	(ULL(1) << 40)
 
 #define MAX_MMAP_REGIONS		8
-#define MAX_XLAT_TABLES			4
+#define MAX_XLAT_TABLES			5
 
 #define MAX_IO_DEVICES			U(3)
 #define MAX_IO_HANDLES			U(4)

--- a/plat/rpi/rpi5/include/rpi5_smc.h
+++ b/plat/rpi/rpi5/include/rpi5_smc.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PLAT_RPI_RPI5_INCLUDE_RPI5_SMC_H_
+#define PLAT_RPI_RPI5_INCLUDE_RPI5_SMC_H_
+
+#include <lib/smccc.h>
+
+/*
+ * Process scmi message pending in the SCMI message
+ * shared memory buffer.
+ */
+#define RPI5_SIP_SMC_SCMI 0x82000002
+
+#endif /* PLAT_RPI_RPI5_INCLUDE_RPI5_SMC_H_ */

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -92,6 +92,15 @@ SCMI_SERVER_SUPPORT		:= 1
 # Process platform flags
 # ----------------------
 
+ifdef SCMI_SERVER_SUPPORT
+#SCMI Server sources
+BL31_SOURCES		+= drivers/scmi-msg/base.c			\
+				drivers/scmi-msg/entry.c		\
+				drivers/scmi-msg/smt.c			\
+				plat/rpi/rpi5/scmi/scmi.c		\
+				plat/rpi/rpi5/rpi5_svc_setup.c
+endif
+
 $(eval $(call add_define,RPI3_BL33_IN_AARCH32))
 $(eval $(call add_define,RPI3_DIRECT_LINUX_BOOT))
 ifdef RPI3_PRELOADED_DTB_BASE

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -86,6 +86,9 @@ RPI3_RUNTIME_UART		:= 0
 # Use normal memory mapping for ROM, FIP, SRAM and DRAM
 RPI3_USE_UEFI_MAP		:= 0
 
+# Enable SCMI server support for RPI5
+SCMI_SERVER_SUPPORT		:= 1
+
 # Process platform flags
 # ----------------------
 
@@ -96,6 +99,14 @@ $(eval $(call add_define,RPI3_PRELOADED_DTB_BASE))
 endif
 $(eval $(call add_define,RPI3_RUNTIME_UART))
 $(eval $(call add_define,RPI3_USE_UEFI_MAP))
+$(eval $(call add_define,SCMI_SERVER_SUPPORT))
+
+ifdef SCMI_SERVER_SUPPORT
+RPI_SCMI_SHMEM_BASE := 0x3ff00000
+RPI_SCMI_SHMEM_SIZE := 0x10000
+$(eval $(call add_define,RPI_SCMI_SHMEM_BASE))
+$(eval $(call add_define,RPI_SCMI_SHMEM_SIZE))
+endif
 
 ifeq (${ARCH},aarch32)
   $(error Error: AArch32 not supported on rpi5)

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -97,7 +97,9 @@ ifdef SCMI_SERVER_SUPPORT
 BL31_SOURCES		+= drivers/scmi-msg/base.c			\
 				drivers/scmi-msg/entry.c		\
 				drivers/scmi-msg/smt.c			\
+				drivers/scmi-msg/reset_domain.c		\
 				plat/rpi/rpi5/scmi/scmi.c		\
+				plat/rpi/rpi5/scmi/scmi_reset.c		\
 				plat/rpi/rpi5/rpi5_svc_setup.c
 endif
 

--- a/plat/rpi/rpi5/rpi5_setup.c
+++ b/plat/rpi/rpi5/rpi5_setup.c
@@ -6,7 +6,13 @@
 
 #include <rpi_shared.h>
 
+#ifdef SCMI_SERVER_SUPPORT
+extern void rpi5_init_scmi_server(void);
+#endif
+
 void plat_rpi_bl31_custom_setup(void)
 {
-	/* Nothing to do here yet. */
+#ifdef SCMI_SERVER_SUPPORT
+	rpi5_init_scmi_server();
+#endif
 }

--- a/plat/rpi/rpi5/rpi5_svc_setup.c
+++ b/plat/rpi/rpi5/rpi5_svc_setup.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <common/debug.h>
+#include <common/runtime_svc.h>
+#include <drivers/scmi-msg.h>
+
+#include <rpi5_smc.h>
+
+/* Setup Standard Services */
+static int32_t rpi5_svc_setup(void)
+{
+	return 0;
+}
+
+/*
+ * Top-level Standard Service SMC handler.
+ */
+static uintptr_t rpi5_svc_smc_handler(uint32_t smc_fid, u_register_t x1,
+					  u_register_t x2, u_register_t x3,
+					  u_register_t x4, void *cookie,
+					  void *handle, u_register_t flags)
+{
+	uint32_t ret1 = 0U;
+
+	switch (smc_fid) {
+	case RPI5_SIP_SMC_SCMI:
+		scmi_smt_fastcall_smc_entry(0);
+		break;
+
+	default:
+		WARN("Unknown RPI5 Service Call: 0x%x\n", smc_fid);
+		ret1 = SMC_UNK;
+		break;
+	}
+
+	SMC_RET1(handle, ret1);
+}
+
+/* Register Standard Service Calls as runtime service */
+DECLARE_RT_SVC(rpi5_sip_svc,
+	       OEN_SIP_START,
+	       OEN_SIP_END,
+	       SMC_TYPE_FAST,
+	       rpi5_svc_setup,
+	       rpi5_svc_smc_handler
+);

--- a/plat/rpi/rpi5/scmi/scmi.c
+++ b/plat/rpi/rpi5/scmi/scmi.c
@@ -42,6 +42,7 @@ const char *plat_scmi_sub_vendor_name(void)
 }
 
 static const uint8_t plat_protocol_list[] = {
+	SCMI_PROTOCOL_ID_RESET_DOMAIN,
 	0U /* Null termination */
 };
 

--- a/plat/rpi/rpi5/scmi/scmi.c
+++ b/plat/rpi/rpi5/scmi/scmi.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdint.h>
+
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+
+#include <platform_def.h>
+
+#define RPI_SHM_BASE		RPI_SCMI_SHMEM_BASE
+#define RPI_SHM0_BASE	RPI_SHM_BASE
+
+static struct scmi_msg_channel scmi_channel[] = {
+	[0] = {
+		.shm_addr = RPI_SHM0_BASE,
+		.shm_size = SMT_BUF_SLOT_SIZE,
+	},
+};
+
+struct scmi_msg_channel *plat_scmi_get_channel(unsigned int agent_id)
+{
+	assert(agent_id < ARRAY_SIZE(scmi_channel));
+
+	return &scmi_channel[agent_id];
+}
+
+static const char vendor[] = "EPAM";
+static const char sub_vendor[] = "";
+
+const char *plat_scmi_vendor_name(void)
+{
+	return vendor;
+}
+
+const char *plat_scmi_sub_vendor_name(void)
+{
+	return sub_vendor;
+}
+
+static const uint8_t plat_protocol_list[] = {
+	0U /* Null termination */
+};
+
+size_t plat_scmi_protocol_count(void)
+{
+	return ARRAY_SIZE(plat_protocol_list) - 1U;
+}
+
+const uint8_t *plat_scmi_protocol_list(unsigned int agent_id __unused)
+{
+	return plat_protocol_list;
+}
+
+void rpi5_init_scmi_server(void)
+{
+	size_t i;
+
+	for (i = 0U; i < ARRAY_SIZE(scmi_channel); i++) {
+		scmi_smt_init_agent_channel(&scmi_channel[i]);
+	}
+}

--- a/plat/rpi/rpi5/scmi/scmi_reset.c
+++ b/plat/rpi/rpi5/scmi/scmi_reset.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdint.h>
+
+#include <common/debug.h>
+#include <drivers/scmi.h>
+#include <lib/utils_def.h>
+#include <platform_def.h>
+
+size_t plat_scmi_rstd_count(unsigned int agent_id __unused)
+{
+	return 0U;
+}
+
+const char *plat_scmi_rstd_get_name(unsigned int agent_id __unused,
+				  unsigned int scmi_id __unused)
+{
+	return NULL;
+}
+
+int32_t plat_scmi_rstd_autonomous(unsigned int agent_id __unused,
+				unsigned int scmi_id __unused,
+				unsigned int state __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}
+
+int32_t plat_scmi_rstd_set_state(unsigned int agent_id __unused,
+			       unsigned int scmi_id __unused,
+			       bool assert_not_deassert __unused)
+{
+	return SCMI_NOT_SUPPORTED;
+}


### PR DESCRIPTION
This functionality introduces the following features:

Add generic scmi support to the arm-tf including base protocol with the communication via SMC and shared pages.
Dummy reset driver which implements required callbacks and shows messages on console.

