### PR TITLE
plat: rpi: rpi5: scmi_reset: PCIe support implementation

### DIFF
--- a/plat/rpi/rpi5/include/rpi5_scmi_resources.h
+++ b/plat/rpi/rpi5/include/rpi5_scmi_resources.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RPI5_SCMI_RESOURCES_H
+#define RPI5_SCMI_RESOURCES_H
+
+struct scmi_reset {
+	const char *name;
+	uint32_t id;
+};
+enum rcar_scmi_rst_offset {
+	RPI5_SCMIRST_PCIE1_1,	/* 0 */
+	RPI5_SCMIRST_PCIE1_2,	/* 1 */
+	RPI5_SCMIRST_PCIE2_1,	/* 2 */
+	RPI5_SCMIRST_PCIE2_2,	/* 3 */
+	RPI5_SCMIRST_MAX
+};
+
+#endif /* RPI5_SCMI_RESOURCES_H */

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -27,6 +27,7 @@ BL31_SOURCES		+=	lib/cpus/aarch64/cortex_a76.S			\
 				plat/rpi/common/rpi3_pm.c			\
 				plat/common/plat_psci_common.c			\
 				plat/rpi/common/rpi3_topology.c			\
+				drivers/delay_timer/generic_delay_timer.c	\
 				${GICV2_SOURCES}
 
 # For now we only support BL31, using the kernel loaded by the GPU firmware.

--- a/plat/rpi/rpi5/rpi5_setup.c
+++ b/plat/rpi/rpi5/rpi5_setup.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <drivers/generic_delay_timer.h>
 #include <rpi_shared.h>
 
 #ifdef SCMI_SERVER_SUPPORT
@@ -12,6 +13,9 @@ extern void rpi5_init_scmi_server(void);
 
 void plat_rpi_bl31_custom_setup(void)
 {
+	/* Enable arch timer */
+	generic_delay_timer_init();
+
 #ifdef SCMI_SERVER_SUPPORT
 	rpi5_init_scmi_server();
 #endif

--- a/plat/rpi/rpi5/scmi/scmi_reset.c
+++ b/plat/rpi/rpi5/scmi/scmi_reset.c
@@ -7,31 +7,143 @@
 #include <stdint.h>
 
 #include <common/debug.h>
+#include <drivers/delay_timer.h>
 #include <drivers/scmi.h>
 #include <lib/utils_def.h>
 #include <platform_def.h>
+#include <lib/mmio.h>
+
+#include "rpi5_scmi_resources.h"
+
+#define SW_INIT_SET		0x00
+#define SW_INIT_CLEAR		0x04
+#define SW_INIT_STATUS		0x08
+
+#define SW_INIT_BIT(id)		BIT((id) & 0x1f)
+#define SW_INIT_BANK(id)	((id) >> 5)
+
+#define SW_INIT_BASE U(0x1001504318)
+/* A full bank contains extra registers that we are not utilizing but still
+ * qualify as a single bank.
+ */
+#define SW_INIT_BANK_SIZE	0x18
+
+struct scmi_reset rpi5_resets[RPI5_SCMIRST_MAX] = {
+	[RPI5_SCMIRST_PCIE1_1] = {
+		.name = "swinit_pcie1",
+		.id = 7,
+	},
+	[RPI5_SCMIRST_PCIE1_2] = {
+		.name = "bridge_pcie1",
+		.id = 43,
+	},
+	[RPI5_SCMIRST_PCIE2_1] = {
+		.name = "swinit_pcie2",
+		.id = 32,
+	},
+	[RPI5_SCMIRST_PCIE2_2] = {
+		.name = "bridge_pcie2",
+		.id = 44,
+	},
+};
+
+static int brcmstb_reset_assert(unsigned int scmi_id)
+{
+	unsigned int off = SW_INIT_BANK(rpi5_resets[scmi_id].id) * SW_INIT_BANK_SIZE;
+
+	mmio_write_32(SW_INIT_BASE + off + SW_INIT_SET,
+			SW_INIT_BIT(rpi5_resets[scmi_id].id));
+
+	return 0;
+}
+
+static int brcmstb_reset_deassert(unsigned int scmi_id)
+{
+	unsigned int off = SW_INIT_BANK(rpi5_resets[scmi_id].id) * SW_INIT_BANK_SIZE;
+
+	mmio_write_32(SW_INIT_BASE + off + SW_INIT_CLEAR,
+			SW_INIT_BIT(rpi5_resets[scmi_id].id));
+
+	/* Maximum reset delay after de-asserting a line and seeing block
+	 * operation is typically 14us for the worst case, build some slack
+	 * here.
+	 */
+	udelay(14);
+
+	return 0;
+}
+
+static int brcmstb_reset_status(unsigned int scmi_id)
+{
+	unsigned int off = SW_INIT_BANK(rpi5_resets[scmi_id].id) * SW_INIT_BANK_SIZE;
+
+	return mmio_read_32(SW_INIT_BASE + off + SW_INIT_STATUS) &
+			     SW_INIT_BIT(rpi5_resets[scmi_id].id);
+}
 
 size_t plat_scmi_rstd_count(unsigned int agent_id __unused)
 {
-	return 0U;
+	return RPI5_SCMIRST_MAX;
 }
 
 const char *plat_scmi_rstd_get_name(unsigned int agent_id __unused,
-				  unsigned int scmi_id __unused)
+				  unsigned int scmi_id)
 {
-	return NULL;
+	if (scmi_id >= RPI5_SCMIRST_MAX) {
+		ERROR("Unable to get reset name, id %d is invalid", scmi_id);
+		return NULL;
+	}
+
+	return rpi5_resets[scmi_id].name;
 }
 
 int32_t plat_scmi_rstd_autonomous(unsigned int agent_id __unused,
-				unsigned int scmi_id __unused,
+				unsigned int scmi_id,
 				unsigned int state __unused)
 {
-	return SCMI_NOT_SUPPORTED;
+	int rc;
+	/*
+	 * According to the information from the following Linux kernel commit:
+	 * 95a15d80aa0d (firmware: arm_scmi: Add RESET protocol in SCMI v2.0, 2019-07-08)
+	 * autonomous reset stands for assert and then deassert, performed by ARM-TF.
+	 * So if reset was asserted then just do deassert, if deasserted
+	 * then assert/deassert.
+	 */
+	if (scmi_id >= RPI5_SCMIRST_MAX) {
+		ERROR("Unable to set autonomous reset, id %d is invalid", scmi_id);
+		return SCMI_INVALID_PARAMETERS;
+	}
+
+	if (!brcmstb_reset_status(scmi_id)) {
+		rc = brcmstb_reset_assert(scmi_id);
+		if (rc) {
+			ERROR("Unable to assert %d", scmi_id);
+			return rc;
+		}
+	}
+
+	rc = brcmstb_reset_deassert(scmi_id);
+	if (rc) {
+		ERROR("Unable to deassert %d", scmi_id);
+		return rc;
+	}
+
+	return SCMI_SUCCESS;
 }
 
 int32_t plat_scmi_rstd_set_state(unsigned int agent_id __unused,
-			       unsigned int scmi_id __unused,
-			       bool assert_not_deassert __unused)
+			       unsigned int scmi_id,
+			       bool assert_not_deassert)
 {
-	return SCMI_NOT_SUPPORTED;
+	int rc;
+
+	if (scmi_id >= RPI5_SCMIRST_MAX) {
+		ERROR("Unable to set reset state, id %d is invalid", scmi_id);
+		return SCMI_INVALID_PARAMETERS;
+	}
+
+	rc = (assert_not_deassert) ? brcmstb_reset_assert(scmi_id) :
+			 brcmstb_reset_deassert(scmi_id);
+
+	return (rc == 0) ? SCMI_SUCCESS : rc;
 }


### PR DESCRIPTION
Basic implementation of the brcm,brcmstb-reset driver inspired by the linux kernel implementation. It is based on the commit-id:

c04af98514c2 (Merge remote-tracking branch 'stable/linux-6.6.y' into rpi-6.6.y, 2024-03-19)

For now the following resets are supported:
- bridge and swinit reset for pcie1
- bridge and swinit reset for pcie2