### PR TITLE
rpi5: add OP-TEE support

### DIFF
--- a/docs/plat/rpi5.rst
+++ b/docs/plat/rpi5.rst
@@ -65,6 +65,23 @@ options may be necessary.
 By default, all boot stages print messages to the dedicated UART debug port.
 Configuration is ``115200 8n1``.
 
+OP-TEE
+------
+
+It is possible to use OP-TEE. But there is a caveat: OP-TEE image should be
+load together with TF-A image, but RPI loader can load one file only. Solution
+is to pack TF-A and OP-TEE into one image.
+
+Build TF-A with ``SPD=opteed`` option and then attach OP-TEE image to TF-A:
+
+.. code:: shell
+
+    cp build/rpi5/debug/bl31.bin bl31_bl32.bin
+    dd if=tee-raw.bin of=bl31_bl32.bin bs=1024 seek=512
+
+Then copy resulting ``bl31_bl32.bin`` to boot media as described in
+the previous section.
+
 Design
 ------------------
 

--- a/plat/rpi/common/rpi3_common.c
+++ b/plat/rpi/common/rpi3_common.c
@@ -48,6 +48,12 @@
 				RPI3_OPTEE_PAGEABLE_LOAD_BASE,	\
 				RPI3_OPTEE_PAGEABLE_LOAD_SIZE,	\
 				MT_MEMORY | MT_RW | MT_SECURE)
+# ifdef RPI_OPTEE_IMAGE_BASE
+# define MAP_OPTEE_IMAGE_PAGEABLE	MAP_REGION_FLAT(		\
+					RPI_OPTEE_IMAGE_BASE,		\
+					RPI_OPTEE_IMAGE_SIZE,		\
+					MT_MEMORY | MT_RW | MT_SECURE)
+# endif
 #endif
 
 #ifdef SCMI_SERVER_SUPPORT
@@ -103,6 +109,9 @@ static const mmap_region_t plat_rpi3_mmap[] = {
 #endif
 #ifdef SCMI_SERVER_SUPPORT
 	MAP_SCMI_MEM,
+#endif
+#ifdef RPI_OPTEE_IMAGE_BASE
+	MAP_OPTEE_IMAGE_PAGEABLE,
 #endif
 	{0}
 };

--- a/plat/rpi/common/rpi4_bl31_setup.c
+++ b/plat/rpi/common/rpi4_bl31_setup.c
@@ -132,6 +132,15 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	/* Initialize the console to provide early debug support. */
 	rpi3_console_init();
 
+#ifdef SPD_opteed
+	VERBOSE("rpi: Moving OP-TEE Image to %x\n", BL32_BASE);
+	memcpy((void*)BL32_BASE, (void*)RPI_OPTEE_IMAGE_BASE,
+	       RPI_OPTEE_IMAGE_SIZE);
+	bl32_image_ep_info.pc = BL32_BASE;
+	bl32_image_ep_info.spsr = rpi3_get_spsr_for_bl33_entry();
+	bl32_image_ep_info.args.arg3 = rpi4_get_dtb_address();
+	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, SECURE);
+#endif
 	bl33_image_ep_info.pc = plat_get_ns_image_entrypoint();
 	bl33_image_ep_info.spsr = rpi3_get_spsr_for_bl33_entry();
 	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);

--- a/plat/rpi/rpi5/include/platform_def.h
+++ b/plat/rpi/rpi5/include/platform_def.h
@@ -117,8 +117,8 @@
 #define PLAT_PHY_ADDR_SPACE_SIZE	(ULL(1) << 40)
 #define PLAT_VIRT_ADDR_SPACE_SIZE	(ULL(1) << 40)
 
-#define MAX_MMAP_REGIONS		8
-#define MAX_XLAT_TABLES			5
+#define MAX_MMAP_REGIONS		9
+#define MAX_XLAT_TABLES			9
 
 #define MAX_IO_DEVICES			U(3)
 #define MAX_IO_HANDLES			U(4)

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -123,6 +123,25 @@ ifeq (${ARCH},aarch32)
   $(error Error: AArch32 not supported on rpi5)
 endif
 
+ifeq (${SPD},opteed)
+
+# Very end of first 2GB
+BL32_BASE		?= 0x1D000000
+BL32_MEM_SIZE		?= 0x02000000
+BL32_MEM_BASE		= BL32_BASE
+
+# We expect that OP-TEE image will be placed right after TF-A
+RPI_OPTEE_IMAGE_BASE	?= 0x80000
+# 1MB should be enough
+RPI_OPTEE_IMAGE_SIZE	?= 0x100000
+
+$(eval $(call add_define,BL32_MEM_BASE))
+$(eval $(call add_define,BL32_MEM_SIZE))
+$(eval $(call add_define,BL32_BASE))
+$(eval $(call add_define,RPI_OPTEE_IMAGE_BASE))
+$(eval $(call add_define,RPI_OPTEE_IMAGE_SIZE))
+endif
+
 ifneq ($(ENABLE_STACK_PROTECTOR), 0)
 PLAT_BL_COMMON_SOURCES	+=	drivers/rpi3/rng/rpi3_rng.c		\
 				plat/rpi/common/rpi3_stack_protector.c


### PR DESCRIPTION
Merge Optee support to the arm-tf because SCMI overlaps some places with optee in the memory map so patch no longer can be applied without conflicts. So I think it's time to merge this to the rpi5_dev branch.


OP-TEE support for RPI5 differs from the RPI3 one because on RPI5 we have BL31 only and there is no way to load additional image into memory. Only option is to attach OP-TEE image to the end of BL31 so they can be loaded together by VPU.

So this patch assumes that OP-TEE image is located right after BL31 at address 0x80000. But we can't boot OP-TEE at this address because VPU will put kernel right behind OP-TEE image, at 0x200000. It is not possible to change kernel load address with `kernel_address=` option in config.txt anymore. This option was moved to "legacy options" ([1]) and is not officially supported anymore. That means that BL31 should move OP-TEE to an empty memory region. By default BL31 moves it at the end of 1GB block, but this can be changed with BL31_BASE parameter.

BL31 will pass DTB address to the OP-TEE, so it will be able to reserve memory for itself and provide correct entries in /firmware section.

Documentation describes how to attach OP-TEE image to BL31.

[1] https://www.raspberrypi.com/documentation/computers/legacy_config_txt.html#kernel_address

Change-Id: I375ca19e7234053b9d6cee6b644ecc55492d85f2