### PR TITLE
Draft: Add Pinctrl SCMI skeleton to ARM-TF

### DIFF
--- a/docs/plat/rpi5.rst
+++ b/docs/plat/rpi5.rst
@@ -65,6 +65,23 @@ options may be necessary.
 By default, all boot stages print messages to the dedicated UART debug port.
 Configuration is ``115200 8n1``.
 
+OP-TEE
+------
+
+It is possible to use OP-TEE. But there is a caveat: OP-TEE image should be
+load together with TF-A image, but RPI loader can load one file only. Solution
+is to pack TF-A and OP-TEE into one image.
+
+Build TF-A with ``SPD=opteed`` option and then attach OP-TEE image to TF-A:
+
+.. code:: shell
+
+    cp build/rpi5/debug/bl31.bin bl31_bl32.bin
+    dd if=tee-raw.bin of=bl31_bl32.bin bs=1024 seek=512
+
+Then copy resulting ``bl31_bl32.bin`` to boot media as described in
+the previous section.
+
 Design
 ------------------
 

--- a/drivers/scmi-msg/common.h
+++ b/drivers/scmi-msg/common.h
@@ -128,6 +128,13 @@ scmi_msg_handler_t scmi_msg_get_pd_handler(struct scmi_msg *msg);
 scmi_msg_handler_t scmi_msg_get_sensor_handler(struct scmi_msg *msg);
 
 /*
+ * scmi_msg_get_pinctrl_handler - Return a handler for a pinctrl message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_pinctrl_handler(struct scmi_msg *msg);
+
+/*
  * Process Read, process and write response for input SCMI message
  *
  * @msg: SCMI message context

--- a/drivers/scmi-msg/common.h
+++ b/drivers/scmi-msg/common.h
@@ -13,6 +13,7 @@
 
 #include "base.h"
 #include "clock.h"
+#include "pinctrl.h"
 #include "power_domain.h"
 #include "reset_domain.h"
 #include "sensor.h"

--- a/drivers/scmi-msg/entry.c
+++ b/drivers/scmi-msg/entry.c
@@ -84,6 +84,9 @@ void scmi_process_message(struct scmi_msg *msg)
 	case SCMI_PROTOCOL_ID_SENSOR:
 		handler = scmi_msg_get_sensor_handler(msg);
 		break;
+	case SCMI_PROTOCOL_ID_PINCTRL:
+		handler = scmi_msg_get_pinctrl_handler(msg);
+		break;
 	default:
 		break;
 	}

--- a/drivers/scmi-msg/pinctrl.c
+++ b/drivers/scmi-msg/pinctrl.c
@@ -171,7 +171,8 @@ static void report_attributes(struct scmi_msg *msg)
 
 static void report_message_attributes(struct scmi_msg *msg)
 {
-	struct attrs_rx_m {
+        uint32_t id = *(uint32_t *)msg->in;
+        struct attrs_rx_m {
 		int32_t status;
 		uint32_t attrs;
 	} return_values = {
@@ -179,7 +180,7 @@ static void report_message_attributes(struct scmi_msg *msg)
 			.attrs = 0,
 	};
 
-	if (msg->in_size != sizeof(id)) {
+        if (msg->in_size != sizeof(id)) {
 		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
 		return;
 	}

--- a/drivers/scmi-msg/pinctrl.c
+++ b/drivers/scmi-msg/pinctrl.c
@@ -1,0 +1,551 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2024, EPAM Systems
+ */
+#include <cdefs.h>
+#include <string.h>
+
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <lib/utils.h>
+#include <lib/utils_def.h>
+
+#include "common.h"
+#define PP(fmt, ...) \
+	INFO("==== %s %d " fmt "\n", __func__, __LINE__, ##__VA_ARGS__);
+
+#pragma weak plat_scmi_pinctrl_count
+#pragma weak plat_scmi_pinctrl_get_name
+#pragma weak plat_scmi_pinctrl_autonomous
+#pragma weak plat_scmi_pinctrl_set_state
+
+//TODO move to header
+struct pinctrl_pin {
+	uint16_t pin;
+	uint16_t enum_id;
+	const char *name;
+	unsigned int configs;
+};
+
+size_t plat_scmi_pinctrl_count(unsigned int agent_id __unused)
+{
+	return 0U;
+}
+
+uint16_t pinctrl_get_groups_count()
+{
+	return 2U;
+}
+
+uint16_t pinctrl_get_functions_count()
+{
+	return 2U;
+}
+
+//TODO remove that
+//allocate pins
+static struct pinctrl_pin l_pins[] = {
+		{
+			.configs = 1,
+			.enum_id = 1,
+			.name = "test_pin",
+			.pin = 1
+		},
+		{
+			.configs = 1,
+			.enum_id = 2,
+			.name = "test_pin2",
+			.pin = 2
+		}
+};
+
+int pinctrl_get_pins(const struct pinctrl_pin **pins, unsigned *num_pins)
+{
+	*pins = &l_pins[0];
+	*num_pins = 2;
+	return 0U;
+}
+
+const char *pinctrl_get_function_name(unsigned selector)
+{
+  return "function";
+}
+
+const char *pinctrl_get_group_name(unsigned selector) {
+	return "group";
+}
+
+const char *plat_scmi_pinctrl_get_name(unsigned int agent_id __unused,
+				  unsigned int scmi_id __unused)
+{
+	return NULL;
+}
+static const unsigned l_pins_g[] = {1, 2};
+
+int pinctrl_get_group_pins(unsigned selector, const unsigned **pins,
+					 unsigned *num_pins)
+{
+	*pins = (const unsigned *)&l_pins_g[0];
+	*num_pins = 2;
+	return 0;
+}
+
+static const int l_groups[] ={1, 2};
+int pinctrl_get_function_groups(unsigned selector, const int **groups,
+			  unsigned *num_groups)
+{
+	*groups = (const int *)&l_groups[0];
+	*num_groups = 2;
+	return 0;
+}
+
+int pinctrl_request(unsigned offset)
+{
+	return 0;
+}
+int pinctrl_free(unsigned offset)
+{
+	return 0;
+}
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_PINCTRL,
+	};
+
+	PP("scmi: Process pinctrl protocol_version\n");
+
+	if (msg->in_size != 0U) {
+		PP("");
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	struct attrs_rx {
+		int32_t status;
+		uint32_t attrs_low;
+		uint32_t attrs_high;
+	} return_values = {
+			.status = SCMI_SUCCESS
+	};
+
+	const struct pinctrl_pin *pins;
+	unsigned nr_pins;
+	int ret;
+
+	uint16_t nr_groups = pinctrl_get_groups_count();
+	uint16_t nr_functions = pinctrl_get_functions_count();
+
+//	struct scmi_protocol_attributes_p2a return_values = {
+//		.status = SCMI_SUCCESS,
+//		.attributes = plat_scmi_pinctrl_count(msg->agent_id),
+//	};
+
+	if (msg->in_size != 0U) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+	ret = pinctrl_get_pins(&pins, &nr_pins);
+	if (ret) {
+		ERROR("scmi: pinctrl_get_pins failed with ret = %d\n", ret);
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	};
+
+	return_values.attrs_low = FLD(GENMASK(31, 16), nr_groups) |
+		FLD(GENMASK(15,  0), nr_pins);
+	return_values.attrs_high = FLD(GENMASK(15, 0), nr_functions);
+
+	WARN("scmi: Process pinctrl protocol_attrs group_max = %d, func_max = %d nr_pins = %d\n",
+		    nr_groups, nr_functions, nr_pins);
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct attrs_rx_m {
+		int32_t status;
+		uint32_t attrs;
+	} return_values = {
+			.status = SCMI_SUCCESS,
+			.attrs = 0,
+	};
+
+	if (msg->in_size != sizeof(id)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+struct pin_attrs_rx {
+	int32_t status;
+	uint32_t attributes;
+	char name[16];
+};
+
+static int set_rx(struct pin_attrs_rx *rx, const char *name, unsigned n_elems)
+{
+	assert(name != NULL);
+
+	rx->attributes = FLD(GENMASK(15, 0), n_elems);
+	if (sizeof(name) > sizeof(rx->name))
+		rx->attributes |= FLD(31, 1);
+	else
+		strlcpy(rx->name, name, sizeof(rx->name));
+
+	return SCMI_SUCCESS;
+}
+
+static void scmi_pinctrl_attributes(struct scmi_msg *msg)
+{
+	struct pin_attrs_tx {
+		uint32_t identifier;
+		uint32_t flags;
+	} in_args = *(struct pin_attrs_tx *)msg->in;
+	struct pin_attrs_rx return_values;
+
+	unsigned nelems;
+	unsigned nr_pins;
+	const struct pinctrl_pin *pins;
+	uint32_t selector = in_args.identifier;
+	int ret;
+	const unsigned *groups;
+	const int *funcs;
+
+	WARN("scmi: pinctrl_attributes id = %d flags = %d\n", in_args.identifier,
+		 in_args.flags);
+
+	if (msg->in_size != sizeof(in_args) || in_args.flags > 2) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	switch (in_args.flags) {
+		case 0:
+			ret = pinctrl_get_pins(&pins, &nr_pins);
+			if (ret || selector > nr_pins) {
+				ERROR("scmi: pinctrl_get_pins failed with ret = %d\n", ret);
+				scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+			};
+			return_values.status = set_rx(&return_values, pins[selector].name, nr_pins);
+			break;
+		case 1:
+			if (selector > pinctrl_get_groups_count()) {
+				ERROR("scmi: pinctrl_get_groups_count failed with sel = %d\n", selector);
+				scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+			};
+
+			ret = pinctrl_get_group_pins(selector, &groups, &nelems);
+			if (ret) {
+				ERROR("scmi: pinctrl_get_group_pins failed with ret = %d\n", ret);
+				scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+			}
+
+			return_values.status = set_rx(&return_values, pinctrl_get_group_name(selector), nelems);
+			break;
+		case 2:
+			if (selector > pinctrl_get_functions_count()) {
+				ERROR("scmi: pinctrl_get_functions_count failed with sel = %d\n",
+					  selector);
+				scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+			};
+
+			ret = pinctrl_get_function_groups(selector, &funcs, &nelems);
+			if (ret) {
+				ERROR("scmi: pinctrl_get_fucntion_groups failed with ret = %d\n", ret);
+				scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+			}
+
+			return_values.status = set_rx(&return_values, pinctrl_get_function_name(selector), nelems);
+			break;
+		default:
+			scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		}
+
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+struct pin_assoc_tx {
+	uint32_t identifier;
+	uint32_t flags;
+	uint32_t index;
+};
+
+struct pin_assoc_rx {
+	int32_t status;
+	uint32_t flags;
+	uint16_t array[];
+};
+
+static uint32_t get_group_pins(struct pin_assoc_tx *tx, struct pin_assoc_rx *rx)
+{
+	uint32_t max_payload_size = SCMI_PLAYLOAD_MAX - sizeof(*rx);
+	int counter = 0, lcounter = 0;
+
+	const unsigned *pins;
+	unsigned nr_pins;
+	int ret;
+
+	WARN("scmi: pinctrl get_group_pins sel = %d skip = %d\n", tx->identifier,
+		 tx->index);
+
+	ret = pinctrl_get_group_pins(tx->identifier, &pins, &nr_pins);
+	if (ret) {
+		ERROR("scmi: pinctrl_get_group_pins failed with ret = %d\n", ret);
+		rx->status = SCMI_GENERIC_ERROR;
+		return sizeof(rx->status);
+	}
+
+	for (counter = tx->index; counter < nr_pins; counter++, lcounter++) {
+		if (lcounter * sizeof(uint16_t) >= max_payload_size) {
+			break;
+		}
+
+		rx->array[lcounter] = pins[counter];
+		WARN("group pins [%d] = %d\n", lcounter, rx->array[lcounter]);
+		WARN("arr addr = %lx\n", (uint64_t)(&rx->array[lcounter]));
+	}
+
+	rx->flags = FLD(GENMASK(31, 16), nr_pins - counter) |
+		FLD(GENMASK(11, 0), lcounter);
+	WARN("scmi: pinctrl get nr_pins= %d cnt returned = %d sz=%zi\n", nr_pins,
+	     lcounter,
+	     sizeof(*rx) +
+	     ALIGN_NEXT(lcounter * sizeof(uint16_t), sizeof(uint32_t)));
+	rx->status = SCMI_SUCCESS;
+
+	return sizeof(*rx) +
+		ALIGN_NEXT(lcounter * sizeof(uint16_t), sizeof(uint32_t));
+}
+
+static uint32_t get_function_groups(struct pin_assoc_tx *tx, struct pin_assoc_rx *rx)
+{
+	uint32_t max_payload_size = SCMI_PLAYLOAD_MAX - sizeof(*rx);
+	int counter = 0, lcounter = 0;
+
+	const int *groups;
+	unsigned nr_groups;
+	int ret;
+
+	WARN("scmi: pinctrl get_func_groups sel = %d skip = %d\n", tx->identifier,
+		 tx->index);
+
+	ret = pinctrl_get_function_groups(tx->identifier, &groups, &nr_groups);
+	if (ret) {
+		ERROR("scmi: pinctrl_get_fucntion_groups failed with ret = %d\n", ret);
+		rx->status = SCMI_GENERIC_ERROR;
+		return sizeof(rx->status);
+	}
+	// TODO amoi sort groups
+	for (counter = tx->index; counter < nr_groups; counter++, lcounter++) {
+		if (lcounter * sizeof(uint16_t) >= max_payload_size) {
+			break;
+		}
+
+		rx->array[lcounter] = groups[counter];
+		WARN("func groups [%d] = %d\n", lcounter, groups[counter]);
+	}
+
+	rx->flags = FLD(GENMASK(31, 16), nr_groups - counter) |
+		FLD(GENMASK(11, 0), lcounter);
+
+	WARN("scmi: pinctrl get nr_groups= %d cnt returned = %d\n", nr_groups,
+		 lcounter);
+	rx->status = SCMI_SUCCESS;
+
+	return sizeof(*rx) +
+		ALIGN_NEXT(lcounter * sizeof(uint16_t), sizeof(uint32_t));
+};
+
+static void scmi_list_associations(struct scmi_msg *msg)
+{
+	struct pin_assoc_tx tx = *(struct pin_assoc_tx *)msg->in;
+	struct pin_assoc_rx rx;
+	int rc;
+
+	WARN("scmi: pinctrl_list_assoc id = %d flags = %d idx = %d\n", tx.identifier,
+		tx.flags, tx.index);
+
+	if (msg->in_size != sizeof(tx) || (tx.flags > 2)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	switch (tx.flags) {
+	case 1:
+		rc = get_group_pins(&tx, &rx);
+		break;
+	case 2:
+		rc = get_function_groups(&tx, &rx);
+		break;
+	default:
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+	scmi_write_response(msg, &rx, rc);
+}
+
+static void scmi_config_get(struct scmi_msg *msg)
+{
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}
+
+static void scmi_config_set(struct scmi_msg *msg)
+{
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}
+
+static void scmi_function_select(struct scmi_msg *msg)
+{
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}
+
+static void scmi_request(struct scmi_msg *msg)
+{ //done not tested
+	struct request_tx {
+		uint32_t identifier;
+		uint32_t flags;
+	} tx = *(struct request_tx *)msg->in;
+	int ret;
+
+	if (msg->in_size != sizeof(tx)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (tx.flags != 0) {
+		WARN("Only pin request is supported\n");
+		scmi_status_response(msg, SCMI_DENIED);
+		return;
+	}
+
+	ret = pinctrl_request(tx.identifier);
+	if (ret) {
+		ERROR("scmi: pinctrl_request_pin failed with ret = %d\n", ret);
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+	//TODO amoi check all returns according to spec
+	scmi_status_response(msg, SCMI_SUCCESS);
+}
+
+static void scmi_release(struct scmi_msg *msg)
+{ //done not tested
+	struct release_tx {
+		uint32_t identifier;
+		uint32_t flags;
+	} tx = *(struct release_tx *)msg->in;
+	int ret;
+
+	if (msg->in_size != sizeof(tx)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (tx.flags != 0) {
+		WARN("Only pin request is supported\n");
+		scmi_status_response(msg, SCMI_DENIED);
+		return;
+	}
+
+	ret = pinctrl_free(tx.identifier);
+	if (ret) {
+		ERROR("scmi: pinctrl_free_pin failed with ret = %d\n", ret);
+		scmi_status_response(msg, SCMI_GENERIC_ERROR);
+		return;
+	}
+
+	scmi_status_response(msg, SCMI_SUCCESS);
+}
+static void scmi_name_get(struct scmi_msg *msg)
+{
+	struct name_tx {
+		uint32_t identifier;
+		uint32_t flags;
+	} tx = *(struct name_tx *)msg->in;
+	struct name_rx {
+		int32_t status;
+		uint32_t flags;
+		char name[64];
+	} rx = {
+			.status = SCMI_SUCCESS,
+			.flags = 0,
+	};
+	int ret;
+	unsigned nr_pins;
+	const struct pinctrl_pin *pins;
+
+	WARN("scmi: pinctrl_name_get id = %d flags = %d\n", tx.identifier,
+		 tx.flags);
+
+	if (msg->in_size != sizeof(tx) || (tx.flags > 2)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+	//TODO make defines
+	switch (tx.flags) {
+	case 0:
+		ret = pinctrl_get_pins(&pins, &nr_pins);
+		if (ret) {
+			ERROR("scmi_name_get: unable to get pins: %d\n", ret);
+			scmi_status_response(msg, SCMI_GENERIC_ERROR);
+			return;
+		}
+
+		strlcpy(rx.name, pins[tx.identifier].name, sizeof(rx.name));
+		break;
+	case 1:
+		strlcpy(rx.name, pinctrl_get_group_name(tx.identifier), sizeof(rx.name));
+		break;
+	case 2:
+		strlcpy(rx.name, pinctrl_get_function_name(tx.identifier), sizeof(rx.name));
+		break;
+	default:
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+	scmi_write_response(msg, &rx, sizeof(rx));
+}
+
+static void scmi_set_permissions(struct scmi_msg *msg)
+{
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}
+
+static const scmi_msg_handler_t scmi_pinctrl_handler_table[] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+    [SCMI_PINCTRL_ATTRIBUTES] = scmi_pinctrl_attributes,
+    [SCMI_PINCTRL_LIST_ASSOCIATIONS] = scmi_list_associations,
+    [SCMI_PINCTRL_CONFIG_GET] = scmi_config_get,
+    [SCMI_PINCTRL_CONFIG_SET] = scmi_config_set,
+    [SCMI_PINCTRL_FUNCTION_SELECT] = scmi_function_select,
+    [SCMI_PINCTRL_REQUEST] = scmi_request,
+    [SCMI_PINCTRL_RELEASE] = scmi_release,
+    [SCMI_PINCTRL_NAME_GET] = scmi_name_get,
+    [SCMI_PINCTRL_SET_PERMISSIONS] = scmi_set_permissions
+};
+
+scmi_msg_handler_t scmi_msg_get_pinctrl_handler(struct scmi_msg *msg)
+{
+	unsigned int message_id = SPECULATION_SAFE_VALUE(msg->message_id);
+
+	if (message_id >= ARRAY_SIZE(scmi_pinctrl_handler_table)) {
+		VERBOSE("Pinctrl domain handle not found %u\n", msg->message_id);
+		return NULL;
+	}
+
+	return scmi_pinctrl_handler_table[message_id];
+}

--- a/drivers/scmi-msg/pinctrl.h
+++ b/drivers/scmi-msg/pinctrl.h
@@ -2,123 +2,129 @@
 /*
  * Copyright (c) 2023, EPAM Systems
  */
-#ifndef SCMI_MSG_PINCTRL_DOMAIN_H
-#define SCMI_MSG_PINCTRL_DOMAIN_H
+#ifndef SCMI_MSG_PINCTRL_H
+#define SCMI_MSG_PINCTRL_H
 
 #include <stdbool.h>
 #include <stdint.h>
 
 #include <lib/utils_def.h>
 
-#define SCMI_PROTOCOL_VERSION_PINCTRL_DOMAIN	0x10000U
+#define SCMI_PROTOCOL_VERSION_PINCTRL	0x10000U
+
+#define ALIGN_NEXT(VALUE, INTERVAL) ((\
+		((VALUE) + (INTERVAL) - 1) / (INTERVAL)) * (INTERVAL))
 
 /*
  * Identifiers of the SCMI Pinctrl Domain Management Protocol commands
  */
 enum scmi_pinctrl_domain_command_id {
-	SCMI_PINCTRL_DOMAIN_ATTRIBUTES = 0x03,
-	SCMI_PINCTRL_DOMAIN_LIST_ASSOCIATIONS = 0x04,
-	SCMI_PINCTRL_DOMAIN_CONFIG_GET = 0x05,
-	SCMI_PINCTRL_DOMAIN_CONFIG_SET = 0x6,
-	SCMI_PINCTRL_DOMAIN_FUNCTION_SELECT = 0x7,
-	SCMI_PINCTRL_DOMAIN_REQUEST = 0x8,
-	SCMI_PINCTRL_DOMAIN_RELEASE = 0x9,
-	SCMI_PINCTRL_DOMAIN_NAME_GET = 0xa,
-	SCMI_PINCTRL_DOMAIN_SET_PERMISSIONS = 0xb,
+	SCMI_PINCTRL_ATTRIBUTES = 0x03,
+	SCMI_PINCTRL_LIST_ASSOCIATIONS = 0x04,
+	SCMI_PINCTRL_CONFIG_GET = 0x05,
+	SCMI_PINCTRL_CONFIG_SET = 0x6,
+	SCMI_PINCTRL_FUNCTION_SELECT = 0x7,
+	SCMI_PINCTRL_REQUEST = 0x8,
+	SCMI_PINCTRL_RELEASE = 0x9,
+	SCMI_PINCTRL_NAME_GET = 0xa,
+	SCMI_PINCTRL_SET_PERMISSIONS = 0xb,
 };
 
-/*
- * Identifiers of the SCMI Pinctrl Domain Management Protocol responses
- */
-enum scmi_pinctrl_domain_response_id {
-	SCMI_PINCTRL_ISSUED = 0x00,
-	SCMI_PINCTRL_COMPLETE = 0x04,
-};
+#define FLD(mask, val) (((val) << (__builtin_ffsll(mask) - 1) & (mask)))
+#define FLD_GET(mask, val) (((val) & (mask)) >> (__builtin_ffsll(mask) - 1))
 
-/*
- * PROTOCOL_ATTRIBUTES
- */
+///*
+// * Identifiers of the SCMI Pinctrl Domain Management Protocol responses
+// */
+//enum scmi_pinctrl_domain_response_id {
+//	SCMI_PINCTRL_ISSUED = 0x00,
+//	SCMI_PINCTRL_COMPLETE = 0x04,
+//};
+//
+///*
+// * PROTOCOL_ATTRIBUTES
+// */
+//
+//#define SCMI_PINCTRL_COUNT_MASK		GENMASK_32(15, 0)
+//
+//struct scmi_reset_domain_protocol_attributes_p2a {
+//	int32_t status;
+//	uint32_t attributes;
+//};
+//
+///* Value for scmi_reset_domain_attributes_p2a:flags */
+//#define SCMI_PINCTRL_ATTR_ASYNC		BIT(31)
+//#define SCMI_PINCTRL_ATTR_NOTIF		BIT(30)
+//
+///* Value for scmi_reset_domain_attributes_p2a:latency */
+//#define SCMI_PINCTRL_ATTR_UNK_LAT		0x7fffffffU
+//#define SCMI_PINCTRL_ATTR_MAX_LAT		0x7ffffffeU
+//
+///* Macro for scmi_reset_domain_attributes_p2a:name */
+//#define SCMI_PINCTRL_ATTR_NAME_SZ		16U
+//
+//struct scmi_reset_domain_attributes_a2p {
+//	uint32_t domain_id;
+//};
+//
+//struct scmi_reset_domain_attributes_p2a {
+//	int32_t status;
+//	uint32_t flags;
+//	uint32_t latency;
+//	char name[SCMI_PINCTRL_ATTR_NAME_SZ];
+//};
+//
+///*
+// * RESET
+// */
+//
+///* Values for scmi_reset_domain_request_a2p:flags */
+//#define SCMI_PINCTRL_ASYNC			BIT(2)
+//#define SCMI_PINCTRL_EXPLICIT		BIT(1)
+//#define SCMI_PINCTRL_AUTO			BIT(0)
+//
+//struct scmi_reset_domain_request_a2p {
+//	uint32_t domain_id;
+//	uint32_t flags;
+//	uint32_t reset_state;
+//};
+//
+//struct scmi_reset_domain_request_p2a {
+//	int32_t status;
+//};
+//
+///*
+// * RESET_NOTIFY
+// */
+//
+///* Values for scmi_reset_notify_p2a:flags */
+//#define SCMI_PINCTRL_DO_NOTIFY		BIT(0)
+//
+//struct scmi_reset_domain_notify_a2p {
+//	uint32_t domain_id;
+//	uint32_t notify_enable;
+//};
+//
+//struct scmi_reset_domain_notify_p2a {
+//	int32_t status;
+//};
+//
+///*
+// * RESET_COMPLETE
+// */
+//
+//struct scmi_reset_domain_complete_p2a {
+//	int32_t status;
+//	uint32_t domain_id;
+//};
+//
+///*
+// * RESET_ISSUED
+// */
+//
+//struct scmi_reset_domain_issued_p2a {
+//	uint32_t domain_id;
+//	uint32_t reset_state;
+//};
 
-#define SCMI_PINCTRL_DOMAIN_COUNT_MASK		GENMASK_32(15, 0)
-
-struct scmi_reset_domain_protocol_attributes_p2a {
-	int32_t status;
-	uint32_t attributes;
-};
-
-/* Value for scmi_reset_domain_attributes_p2a:flags */
-#define SCMI_PINCTRL_DOMAIN_ATTR_ASYNC		BIT(31)
-#define SCMI_PINCTRL_DOMAIN_ATTR_NOTIF		BIT(30)
-
-/* Value for scmi_reset_domain_attributes_p2a:latency */
-#define SCMI_PINCTRL_DOMAIN_ATTR_UNK_LAT		0x7fffffffU
-#define SCMI_PINCTRL_DOMAIN_ATTR_MAX_LAT		0x7ffffffeU
-
-/* Macro for scmi_reset_domain_attributes_p2a:name */
-#define SCMI_PINCTRL_DOMAIN_ATTR_NAME_SZ		16U
-
-struct scmi_reset_domain_attributes_a2p {
-	uint32_t domain_id;
-};
-
-struct scmi_reset_domain_attributes_p2a {
-	int32_t status;
-	uint32_t flags;
-	uint32_t latency;
-	char name[SCMI_PINCTRL_DOMAIN_ATTR_NAME_SZ];
-};
-
-/*
- * RESET
- */
-
-/* Values for scmi_reset_domain_request_a2p:flags */
-#define SCMI_PINCTRL_DOMAIN_ASYNC			BIT(2)
-#define SCMI_PINCTRL_DOMAIN_EXPLICIT		BIT(1)
-#define SCMI_PINCTRL_DOMAIN_AUTO			BIT(0)
-
-struct scmi_reset_domain_request_a2p {
-	uint32_t domain_id;
-	uint32_t flags;
-	uint32_t reset_state;
-};
-
-struct scmi_reset_domain_request_p2a {
-	int32_t status;
-};
-
-/*
- * RESET_NOTIFY
- */
-
-/* Values for scmi_reset_notify_p2a:flags */
-#define SCMI_PINCTRL_DOMAIN_DO_NOTIFY		BIT(0)
-
-struct scmi_reset_domain_notify_a2p {
-	uint32_t domain_id;
-	uint32_t notify_enable;
-};
-
-struct scmi_reset_domain_notify_p2a {
-	int32_t status;
-};
-
-/*
- * RESET_COMPLETE
- */
-
-struct scmi_reset_domain_complete_p2a {
-	int32_t status;
-	uint32_t domain_id;
-};
-
-/*
- * RESET_ISSUED
- */
-
-struct scmi_reset_domain_issued_p2a {
-	uint32_t domain_id;
-	uint32_t reset_state;
-};
-
-#endif /* SCMI_MSG_PINCTRL_DOMAIN_H */
+#endif /* SCMI_MSG_PINCTRL_H */

--- a/drivers/scmi-msg/pinctrl.h
+++ b/drivers/scmi-msg/pinctrl.h
@@ -1,0 +1,124 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright (c) 2023, EPAM Systems
+ */
+#ifndef SCMI_MSG_PINCTRL_DOMAIN_H
+#define SCMI_MSG_PINCTRL_DOMAIN_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <lib/utils_def.h>
+
+#define SCMI_PROTOCOL_VERSION_PINCTRL_DOMAIN	0x10000U
+
+/*
+ * Identifiers of the SCMI Pinctrl Domain Management Protocol commands
+ */
+enum scmi_pinctrl_domain_command_id {
+	SCMI_PINCTRL_DOMAIN_ATTRIBUTES = 0x03,
+	SCMI_PINCTRL_DOMAIN_LIST_ASSOCIATIONS = 0x04,
+	SCMI_PINCTRL_DOMAIN_CONFIG_GET = 0x05,
+	SCMI_PINCTRL_DOMAIN_CONFIG_SET = 0x6,
+	SCMI_PINCTRL_DOMAIN_FUNCTION_SELECT = 0x7,
+	SCMI_PINCTRL_DOMAIN_REQUEST = 0x8,
+	SCMI_PINCTRL_DOMAIN_RELEASE = 0x9,
+	SCMI_PINCTRL_DOMAIN_NAME_GET = 0xa,
+	SCMI_PINCTRL_DOMAIN_SET_PERMISSIONS = 0xb,
+};
+
+/*
+ * Identifiers of the SCMI Pinctrl Domain Management Protocol responses
+ */
+enum scmi_pinctrl_domain_response_id {
+	SCMI_PINCTRL_ISSUED = 0x00,
+	SCMI_PINCTRL_COMPLETE = 0x04,
+};
+
+/*
+ * PROTOCOL_ATTRIBUTES
+ */
+
+#define SCMI_PINCTRL_DOMAIN_COUNT_MASK		GENMASK_32(15, 0)
+
+struct scmi_reset_domain_protocol_attributes_p2a {
+	int32_t status;
+	uint32_t attributes;
+};
+
+/* Value for scmi_reset_domain_attributes_p2a:flags */
+#define SCMI_PINCTRL_DOMAIN_ATTR_ASYNC		BIT(31)
+#define SCMI_PINCTRL_DOMAIN_ATTR_NOTIF		BIT(30)
+
+/* Value for scmi_reset_domain_attributes_p2a:latency */
+#define SCMI_PINCTRL_DOMAIN_ATTR_UNK_LAT		0x7fffffffU
+#define SCMI_PINCTRL_DOMAIN_ATTR_MAX_LAT		0x7ffffffeU
+
+/* Macro for scmi_reset_domain_attributes_p2a:name */
+#define SCMI_PINCTRL_DOMAIN_ATTR_NAME_SZ		16U
+
+struct scmi_reset_domain_attributes_a2p {
+	uint32_t domain_id;
+};
+
+struct scmi_reset_domain_attributes_p2a {
+	int32_t status;
+	uint32_t flags;
+	uint32_t latency;
+	char name[SCMI_PINCTRL_DOMAIN_ATTR_NAME_SZ];
+};
+
+/*
+ * RESET
+ */
+
+/* Values for scmi_reset_domain_request_a2p:flags */
+#define SCMI_PINCTRL_DOMAIN_ASYNC			BIT(2)
+#define SCMI_PINCTRL_DOMAIN_EXPLICIT		BIT(1)
+#define SCMI_PINCTRL_DOMAIN_AUTO			BIT(0)
+
+struct scmi_reset_domain_request_a2p {
+	uint32_t domain_id;
+	uint32_t flags;
+	uint32_t reset_state;
+};
+
+struct scmi_reset_domain_request_p2a {
+	int32_t status;
+};
+
+/*
+ * RESET_NOTIFY
+ */
+
+/* Values for scmi_reset_notify_p2a:flags */
+#define SCMI_PINCTRL_DOMAIN_DO_NOTIFY		BIT(0)
+
+struct scmi_reset_domain_notify_a2p {
+	uint32_t domain_id;
+	uint32_t notify_enable;
+};
+
+struct scmi_reset_domain_notify_p2a {
+	int32_t status;
+};
+
+/*
+ * RESET_COMPLETE
+ */
+
+struct scmi_reset_domain_complete_p2a {
+	int32_t status;
+	uint32_t domain_id;
+};
+
+/*
+ * RESET_ISSUED
+ */
+
+struct scmi_reset_domain_issued_p2a {
+	uint32_t domain_id;
+	uint32_t reset_state;
+};
+
+#endif /* SCMI_MSG_PINCTRL_DOMAIN_H */

--- a/include/drivers/scmi.h
+++ b/include/drivers/scmi.h
@@ -12,6 +12,7 @@
 #define SCMI_PROTOCOL_ID_CLOCK			0x14U
 #define SCMI_PROTOCOL_ID_SENSOR			0x15U
 #define SCMI_PROTOCOL_ID_RESET_DOMAIN		0x16U
+#define SCMI_PROTOCOL_ID_PINCTRL		0x19U
 
 /* SCMI error codes reported to agent through server-to-agent messages */
 #define SCMI_SUCCESS			0

--- a/plat/rpi/common/rpi3_common.c
+++ b/plat/rpi/common/rpi3_common.c
@@ -48,6 +48,12 @@
 				RPI3_OPTEE_PAGEABLE_LOAD_BASE,	\
 				RPI3_OPTEE_PAGEABLE_LOAD_SIZE,	\
 				MT_MEMORY | MT_RW | MT_SECURE)
+# ifdef RPI_OPTEE_IMAGE_BASE
+# define MAP_OPTEE_IMAGE_PAGEABLE	MAP_REGION_FLAT(		\
+					RPI_OPTEE_IMAGE_BASE,		\
+					RPI_OPTEE_IMAGE_SIZE,		\
+					MT_MEMORY | MT_RW | MT_SECURE)
+# endif
 #endif
 
 #ifdef SCMI_SERVER_SUPPORT
@@ -103,6 +109,9 @@ static const mmap_region_t plat_rpi3_mmap[] = {
 #endif
 #ifdef SCMI_SERVER_SUPPORT
 	MAP_SCMI_MEM,
+#endif
+#ifdef RPI_OPTEE_IMAGE_BASE
+	MAP_OPTEE_IMAGE_PAGEABLE,
 #endif
 	{0}
 };

--- a/plat/rpi/common/rpi4_bl31_setup.c
+++ b/plat/rpi/common/rpi4_bl31_setup.c
@@ -132,6 +132,15 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	/* Initialize the console to provide early debug support. */
 	rpi3_console_init();
 
+#ifdef SPD_opteed
+	VERBOSE("rpi: Moving OP-TEE Image to %x\n", BL32_BASE);
+	memcpy((void*)BL32_BASE, (void*)RPI_OPTEE_IMAGE_BASE,
+	       RPI_OPTEE_IMAGE_SIZE);
+	bl32_image_ep_info.pc = BL32_BASE;
+	bl32_image_ep_info.spsr = rpi3_get_spsr_for_bl33_entry();
+	bl32_image_ep_info.args.arg3 = rpi4_get_dtb_address();
+	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, SECURE);
+#endif
 	bl33_image_ep_info.pc = plat_get_ns_image_entrypoint();
 	bl33_image_ep_info.spsr = rpi3_get_spsr_for_bl33_entry();
 	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);

--- a/plat/rpi/rpi5/include/platform_def.h
+++ b/plat/rpi/rpi5/include/platform_def.h
@@ -117,8 +117,8 @@
 #define PLAT_PHY_ADDR_SPACE_SIZE	(ULL(1) << 40)
 #define PLAT_VIRT_ADDR_SPACE_SIZE	(ULL(1) << 40)
 
-#define MAX_MMAP_REGIONS		8
-#define MAX_XLAT_TABLES			5
+#define MAX_MMAP_REGIONS		9
+#define MAX_XLAT_TABLES			9
 
 #define MAX_IO_DEVICES			U(3)
 #define MAX_IO_HANDLES			U(4)

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -124,6 +124,25 @@ ifeq (${ARCH},aarch32)
   $(error Error: AArch32 not supported on rpi5)
 endif
 
+ifeq (${SPD},opteed)
+
+# Very end of first 2GB
+BL32_BASE		?= 0x1D000000
+BL32_MEM_SIZE		?= 0x02000000
+BL32_MEM_BASE		= BL32_BASE
+
+# We expect that OP-TEE image will be placed right after TF-A
+RPI_OPTEE_IMAGE_BASE	?= 0x80000
+# 1MB should be enough
+RPI_OPTEE_IMAGE_SIZE	?= 0x100000
+
+$(eval $(call add_define,BL32_MEM_BASE))
+$(eval $(call add_define,BL32_MEM_SIZE))
+$(eval $(call add_define,BL32_BASE))
+$(eval $(call add_define,RPI_OPTEE_IMAGE_BASE))
+$(eval $(call add_define,RPI_OPTEE_IMAGE_SIZE))
+endif
+
 ifneq ($(ENABLE_STACK_PROTECTOR), 0)
 PLAT_BL_COMMON_SOURCES	+=	drivers/rpi3/rng/rpi3_rng.c		\
 				plat/rpi/common/rpi3_stack_protector.c

--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -99,6 +99,7 @@ BL31_SOURCES		+= drivers/scmi-msg/base.c			\
 				drivers/scmi-msg/entry.c		\
 				drivers/scmi-msg/smt.c			\
 				drivers/scmi-msg/reset_domain.c		\
+				drivers/scmi-msg/pinctrl.c		\
 				plat/rpi/rpi5/scmi/scmi.c		\
 				plat/rpi/rpi5/scmi/scmi_reset.c		\
 				plat/rpi/rpi5/rpi5_svc_setup.c

--- a/plat/rpi/rpi5/scmi/scmi.c
+++ b/plat/rpi/rpi5/scmi/scmi.c
@@ -43,6 +43,7 @@ const char *plat_scmi_sub_vendor_name(void)
 
 static const uint8_t plat_protocol_list[] = {
 	SCMI_PROTOCOL_ID_RESET_DOMAIN,
+	SCMI_PROTOCOL_ID_PINCTRL,
 	0U /* Null termination */
 };
 


### PR DESCRIPTION
Implementation of the first draft of Pinctrl protocol.
All implemented calls returns predefined values. The following calls were tested:
get_version, get_count, get_attributes, list_associations, get_name.

All tests were performed using unit tests in the linux kernel.