### PR TITLE
plat: rpi5: make scmi support optional

### DIFF
--- a/plat/rpi/rpi5/platform.mk
+++ b/plat/rpi/rpi5/platform.mk
@@ -88,12 +88,12 @@ RPI3_RUNTIME_UART		:= 0
 RPI3_USE_UEFI_MAP		:= 0
 
 # Enable SCMI server support for RPI5
-SCMI_SERVER_SUPPORT		:= 1
+SCMI_SERVER_SUPPORT		?= 1
 
 # Process platform flags
 # ----------------------
 
-ifdef SCMI_SERVER_SUPPORT
+ifeq ($(SCMI_SERVER_SUPPORT), 1)
 #SCMI Server sources
 BL31_SOURCES		+= drivers/scmi-msg/base.c			\
 				drivers/scmi-msg/entry.c		\


### PR DESCRIPTION
Now ARM SCMI support is enabled for RPI5 unconditionally. This patch makes it optional and enabled by default.


Acked-by: Oleksii Moisieiev <oleksii_moisieiev@epam.com>

this is reopened PR #17