### PR TITLE
Rcar gen4 v2.7 v4x scmi base

### DIFF
--- a/drivers/scmi-msg/base.c
+++ b/drivers/scmi-msg/base.c
@@ -151,7 +151,8 @@ static void discover_list_protocols(struct scmi_msg *msg)
 	count = count_protocols_in_list(list);
 
 	if (count > a2p->skip) {
-		count = MIN(count - a2p->skip, msg->out_size - sizeof(p2a));
+		count = MIN((uint32_t)(count - a2p->skip),
+			    (uint32_t)(msg->out_size - sizeof(p2a)));
 	} else {
 		count = 0U;
 	}

--- a/drivers/scmi-msg/base.c
+++ b/drivers/scmi-msg/base.c
@@ -131,15 +131,12 @@ static unsigned int count_protocols_in_list(const uint8_t *protocol_list)
 	return count;
 }
 
-#define MAX_PROTOCOL_IN_LIST		8U
-
 static void discover_list_protocols(struct scmi_msg *msg)
 {
 	const struct scmi_base_discover_list_protocols_a2p *a2p = NULL;
 	struct scmi_base_discover_list_protocols_p2a p2a = {
 		.status = SCMI_SUCCESS,
 	};
-	uint8_t outargs[sizeof(p2a) + MAX_PROTOCOL_IN_LIST] = { 0U };
 	const uint8_t *list = NULL;
 	unsigned int count = 0U;
 
@@ -148,24 +145,22 @@ static void discover_list_protocols(struct scmi_msg *msg)
 		return;
 	}
 
-	assert(msg->out_size > sizeof(outargs));
-
 	a2p = (void *)msg->in;
 
 	list = plat_scmi_protocol_list(msg->agent_id);
 	count = count_protocols_in_list(list);
+
 	if (count > a2p->skip) {
-		count = MIN(count - a2p->skip, MAX_PROTOCOL_IN_LIST);
+		count = MIN(count - a2p->skip, msg->out_size - sizeof(p2a));
 	} else {
 		count = 0U;
 	}
 
 	p2a.num_protocols = count;
 
-	memcpy(outargs, &p2a, sizeof(p2a));
-	memcpy(outargs + sizeof(p2a), list + a2p->skip, count);
-
-	scmi_write_response(msg, outargs, sizeof(p2a) + round_up(count, sizeof(uint32_t)));
+	memcpy(msg->out, &p2a, sizeof(p2a));
+	memcpy(msg->out + sizeof(p2a), list + a2p->skip, count);
+	msg->out_size_out = sizeof(p2a) + round_up(count, sizeof(uint32_t));
 }
 
 static const scmi_msg_handler_t scmi_base_handler_table[] = {

--- a/drivers/scmi-msg/base.c
+++ b/drivers/scmi-msg/base.c
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /*
  * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
- * Copyright (c) 2019-2020, Linaro Limited
+ * Copyright (c) 2019-2022, Linaro Limited
  */
 #include <assert.h>
 #include <string.h>
@@ -165,7 +165,7 @@ static void discover_list_protocols(struct scmi_msg *msg)
 	memcpy(outargs, &p2a, sizeof(p2a));
 	memcpy(outargs + sizeof(p2a), list + a2p->skip, count);
 
-	scmi_write_response(msg, outargs, sizeof(outargs));
+	scmi_write_response(msg, outargs, sizeof(p2a) + round_up(count, sizeof(uint32_t)));
 }
 
 static const scmi_msg_handler_t scmi_base_handler_table[] = {

--- a/drivers/scmi-msg/base.c
+++ b/drivers/scmi-msg/base.c
@@ -36,7 +36,9 @@ static void report_attributes(struct scmi_msg *msg)
 	struct scmi_protocol_attributes_p2a return_values = {
 		.status = SCMI_SUCCESS,
 		/* Null agent count since agent discovery is not supported */
-		.attributes = SCMI_BASE_PROTOCOL_ATTRIBUTES(protocol_count, 0U),
+		.attributes =
+		SCMI_BASE_PROTOCOL_ATTRIBUTES(protocol_count,
+					      plat_scmi_agent_count()),
 	};
 
 	if (msg->in_size != 0U) {
@@ -191,4 +193,16 @@ scmi_msg_handler_t scmi_msg_get_base_handler(struct scmi_msg *msg)
 	}
 
 	return scmi_base_handler_table[message_id];
+}
+
+#pragma weak plat_scmi_agent_count
+uint32_t plat_scmi_agent_count(void)
+{
+	return 1;
+}
+
+#pragma weak plat_scmi_agent_get_name
+const char *plat_scmi_agent_get_name(unsigned int agent_id)
+{
+	return NULL;
 }

--- a/drivers/scmi-msg/base.h
+++ b/drivers/scmi-msg/base.h
@@ -72,4 +72,20 @@ struct scmi_base_discover_list_protocols_p2a {
 	uint32_t protocols[];
 };
 
+/*
+ * BASE_DISCOVER_AGENT
+ */
+#define SCMI_BASE_AGENT_ID_OWN 0xFFFFFFFF
+
+struct scmi_base_discover_agent_a2p {
+	uint32_t agent_id;
+};
+
+struct scmi_base_discover_agent_p2a {
+	int32_t status;
+	uint32_t agent_id;
+	char name[SCMI_DEFAULT_STRING_LENGTH];
+};
+
+
 #endif /* SCMI_MSG_BASE_H */

--- a/drivers/scmi-msg/base.h
+++ b/drivers/scmi-msg/base.h
@@ -20,6 +20,9 @@ enum scmi_base_message_id {
 	SCMI_BASE_DISCOVER_LIST_PROTOCOLS		= 0x006,
 	SCMI_BASE_DISCOVER_AGENT			= 0x007,
 	SCMI_BASE_NOTIFY_ERRORS				= 0x008,
+	SCMI_BASE_SET_DEVICE_PERMISSIONS		= 0x009,
+	SCMI_BASE_SET_PROTOCOL_PERMISSIONS		= 0x00A,
+	SCMI_BASE_RESET_AGENT_CONFIGURATION		= 0x00B,
 };
 
 /*
@@ -37,6 +40,13 @@ enum scmi_base_message_id {
 	  SCMI_BASE_PROTOCOL_ATTRS_NUM_PROTOCOLS_MASK) | \
 	(((NUM_AGENTS) << SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_POS) & \
 	 SCMI_BASE_PROTOCOL_ATTRS_NUM_AGENTS_MASK))
+
+/* Value for scmi_base_set_device_permissions_p2a:flags */
+#define SCMI_BASE_ACCESS_TYPE			BIT(0)
+
+/* Value for scmi_base_reset_agent_configuration_p2a:flags */
+#define SCMI_BASE_PERMISSIONS_RESET		BIT(0)
+
 
 /*
  * BASE_DISCOVER_VENDOR
@@ -87,5 +97,30 @@ struct scmi_base_discover_agent_p2a {
 	char name[SCMI_DEFAULT_STRING_LENGTH];
 };
 
+
+/*
+ * BASE_SET_DEVICE_PERMISSIONS
+ */
+struct scmi_base_set_device_permissions_a2p {
+	uint32_t agent_id;
+	uint32_t device_id;
+	uint32_t flags;
+};
+
+struct scmi_base_set_device_permissions_p2a {
+	int32_t status;
+};
+
+/*
+ * BASE_RESET_AGENT_CONFIGURATION
+ */
+struct scmi_base_reset_agent_configuration_a2p {
+	uint32_t agent_id;
+	uint32_t flags;
+};
+
+struct scmi_base_reset_agent_configuration_p2a {
+	int32_t status;
+};
 
 #endif /* SCMI_MSG_BASE_H */

--- a/drivers/scmi-msg/clock.c
+++ b/drivers/scmi-msg/clock.c
@@ -37,7 +37,8 @@ const char *plat_scmi_clock_get_name(unsigned int agent_id __unused,
 int32_t plat_scmi_clock_rates_array(unsigned int agent_id __unused,
 				    unsigned int scmi_id __unused,
 				    unsigned long *rates __unused,
-				    size_t *nb_elts __unused)
+				    size_t *nb_elts __unused,
+				    uint32_t start_idx __unused)
 {
 	return SCMI_NOT_SUPPORTED;
 }
@@ -298,7 +299,7 @@ static void scmi_clock_describe_rates(struct scmi_msg *msg)
 
 	/* Platform may support array rate description */
 	status = plat_scmi_clock_rates_array(msg->agent_id, clock_id, NULL,
-					     &nb_rates);
+					     &nb_rates, 0);
 	if (status == SCMI_SUCCESS) {
 		/* Currently 12 cells mex, so it's affordable for the stack */
 		unsigned long plat_rates[RATES_ARRAY_SIZE_MAX / RATE_DESC_SIZE];
@@ -307,7 +308,8 @@ static void scmi_clock_describe_rates(struct scmi_msg *msg)
 		size_t rem_nb = nb_rates - in_args->rate_index - ret_nb;
 
 		status =  plat_scmi_clock_rates_array(msg->agent_id, clock_id,
-						      plat_rates, &ret_nb);
+						      plat_rates, &ret_nb,
+						      in_args->rate_index);
 		if (status == SCMI_SUCCESS) {
 			write_rate_desc_array_in_buffer(msg->out + sizeof(p2a),
 							plat_rates, ret_nb);

--- a/drivers/scmi-msg/common.h
+++ b/drivers/scmi-msg/common.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /*
- * Copyright (c) 2015-2019, Arm Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2024, Arm Limited and Contributors. All rights reserved.
  * Copyright (c) 2019-2020, Linaro Limited
  */
 #ifndef SCMI_MSG_COMMON_H
@@ -15,6 +15,7 @@
 #include "clock.h"
 #include "power_domain.h"
 #include "reset_domain.h"
+#include "sensor.h"
 
 #define SCMI_VERSION			0x20000U
 #define SCMI_IMPL_VERSION		0U
@@ -117,6 +118,13 @@ scmi_msg_handler_t scmi_msg_get_rstd_handler(struct scmi_msg *msg);
  * Return a function handler for the message or NULL
  */
 scmi_msg_handler_t scmi_msg_get_pd_handler(struct scmi_msg *msg);
+
+/*
+ * scmi_msg_get_sensor_handler - Return a handler for a sensor message
+ * @msg - message to process
+ * Return a function handler for the message or NULL
+ */
+scmi_msg_handler_t scmi_msg_get_sensor_handler(struct scmi_msg *msg);
 
 /*
  * Process Read, process and write response for input SCMI message

--- a/drivers/scmi-msg/entry.c
+++ b/drivers/scmi-msg/entry.c
@@ -15,6 +15,7 @@
 #pragma weak scmi_msg_get_rstd_handler
 #pragma weak scmi_msg_get_pd_handler
 #pragma weak scmi_msg_get_voltage_handler
+#pragma weak scmi_msg_get_sensor_handler
 
 scmi_msg_handler_t scmi_msg_get_clock_handler(struct scmi_msg *msg __unused)
 {
@@ -32,6 +33,11 @@ scmi_msg_handler_t scmi_msg_get_pd_handler(struct scmi_msg *msg __unused)
 }
 
 scmi_msg_handler_t scmi_msg_get_voltage_handler(struct scmi_msg *msg __unused)
+{
+	return NULL;
+}
+
+scmi_msg_handler_t scmi_msg_get_sensor_handler(struct scmi_msg *msg __unused)
 {
 	return NULL;
 }
@@ -74,6 +80,9 @@ void scmi_process_message(struct scmi_msg *msg)
 		break;
 	case SCMI_PROTOCOL_ID_POWER_DOMAIN:
 		handler = scmi_msg_get_pd_handler(msg);
+		break;
+	case SCMI_PROTOCOL_ID_SENSOR:
+		handler = scmi_msg_get_sensor_handler(msg);
 		break;
 	default:
 		break;

--- a/drivers/scmi-msg/reset_domain.c
+++ b/drivers/scmi-msg/reset_domain.c
@@ -19,6 +19,7 @@ static bool message_id_is_supported(unsigned int message_id);
 #pragma weak plat_scmi_rstd_get_name
 #pragma weak plat_scmi_rstd_autonomous
 #pragma weak plat_scmi_rstd_set_state
+#pragma weak plat_scmi_rstd_permitted
 
 size_t plat_scmi_rstd_count(unsigned int agent_id __unused)
 {
@@ -43,6 +44,13 @@ int32_t plat_scmi_rstd_set_state(unsigned int agent_id __unused,
 			       bool assert_not_deassert __unused)
 {
 	return SCMI_NOT_SUPPORTED;
+}
+
+bool plat_scmi_rstd_permitted(uint32_t agent_id, uint32_t domain_id)
+{
+	assert(agent_id < plat_scmi_agent_count());
+
+	return true;
 }
 
 static void report_version(struct scmi_msg *msg)
@@ -148,6 +156,11 @@ static void reset_request(struct scmi_msg *msg)
 
 	if (domain_id >= plat_scmi_rstd_count(msg->agent_id)) {
 		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	if (!plat_scmi_rstd_permitted(msg->agent_id, domain_id)) {
+		scmi_status_response(msg, SCMI_DENIED);
 		return;
 	}
 

--- a/drivers/scmi-msg/sensor.c
+++ b/drivers/scmi-msg/sensor.c
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright 2021-2024 NXP
+ */
+
+#include <cdefs.h>
+#include <string.h>
+
+#include "common.h"
+
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <lib/utils_def.h>
+
+static bool message_id_is_supported(size_t message_id);
+
+uint16_t plat_scmi_sensor_count(unsigned int agent_id __unused)
+{
+	if (sensor_ops.sensor_count != NULL) {
+		return sensor_ops.sensor_count(agent_id);
+	}
+
+	return 0U;
+}
+
+uint8_t plat_scmi_sensor_max_requests(unsigned int agent_id __unused)
+{
+	if (sensor_ops.sensor_max_request != NULL) {
+		return sensor_ops.sensor_max_request(agent_id);
+	}
+
+	return 0U;
+}
+
+uint32_t plat_scmi_sensor_reg(unsigned int agent_id __unused,
+			      unsigned int *addr)
+{
+	if (sensor_ops.get_sensor_req != NULL) {
+		return sensor_ops.get_sensor_req(agent_id, addr);
+	}
+
+	return 0U;
+}
+
+int32_t plat_scmi_sensor_reading_get(uint32_t agent_id __unused,
+				     uint16_t sensor_id __unused,
+				     uint32_t *val __unused)
+{
+	if (sensor_ops.sensor_reading_get != NULL) {
+		return sensor_ops.sensor_reading_get(agent_id, sensor_id, val);
+	}
+
+	return 0;
+}
+
+uint32_t plat_scmi_sensor_description_get(uint32_t agent_id __unused,
+					  uint16_t desc_index __unused,
+					  struct scmi_sensor_desc *desc __unused)
+{
+	if (sensor_ops.sensor_description_get != NULL) {
+		return sensor_ops.sensor_description_get(agent_id, desc_index, desc);
+	}
+
+	return 0U;
+}
+
+uint32_t plat_scmi_sensor_update_interval(uint32_t agent_id __unused,
+					  uint16_t sensor_id __unused)
+{
+	if (sensor_ops.sensor_update_interval != NULL) {
+		return sensor_ops.sensor_update_interval(agent_id, sensor_id);
+	}
+
+	return 0U;
+}
+
+uint32_t plat_scmi_sensor_state(uint32_t agent_id __unused,
+				uint16_t sensor_id __unused)
+{
+	if (sensor_ops.sensor_state != NULL) {
+		return sensor_ops.sensor_state(agent_id, sensor_id);
+	}
+
+	return 0U;
+}
+
+uint32_t plat_scmi_sensor_timestamped(uint32_t agent_id __unused,
+				      uint16_t sensor_id __unused)
+{
+	if (sensor_ops.sensor_timestamped != NULL) {
+		return sensor_ops.sensor_timestamped(agent_id, sensor_id);
+	}
+
+	return 0U;
+}
+
+static void report_version(struct scmi_msg *msg)
+{
+	struct scmi_protocol_version_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		.version = SCMI_PROTOCOL_VERSION_SENSOR,
+	};
+
+	if (msg->in_size != 0U) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_attributes(struct scmi_msg *msg)
+{
+	unsigned int addr[2];
+	unsigned int len;
+
+	struct scmi_protocol_attributes_p2a_sensor return_values = {
+		.status = SCMI_SUCCESS,
+	};
+
+	if (msg->in_size != 0U) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	return_values.num_sensors = plat_scmi_sensor_count(msg->agent_id);
+	return_values.max_reqs = plat_scmi_sensor_max_requests(msg->agent_id);
+	len = plat_scmi_sensor_reg(msg->agent_id, addr);
+	if (len != 0U) {
+		return_values.sensor_reg_low = addr[0];
+		return_values.sensor_reg_high = addr[1];
+		return_values.sensor_reg_len = len;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void report_message_attributes(struct scmi_msg *msg)
+{
+	struct scmi_protocol_message_attributes_a2p *in_args = (void *)msg->in;
+	struct scmi_protocol_message_attributes_p2a return_values = {
+		.status = SCMI_SUCCESS,
+		/* For this protocol, attributes shall be zero */
+		.attributes = 0U,
+	};
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	if (!message_id_is_supported(in_args->message_id)) {
+		scmi_status_response(msg, SCMI_NOT_FOUND);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_sensor_description_get(struct scmi_msg *msg)
+{
+	const struct scmi_sensor_description_get_a2p *in_args = (void *)msg->in;
+	struct scmi_sensor_description_get_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+	struct scmi_sensor_desc desc;
+	unsigned int desc_index = 0U;
+	unsigned int num_sensor_flags;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	desc_index = SPECULATION_SAFE_VALUE(in_args->desc_index);
+
+	num_sensor_flags = plat_scmi_sensor_description_get(msg->agent_id, desc_index,
+							    &desc);
+	return_values.num_sensor_flags = num_sensor_flags;
+
+	memcpy(msg->out, &return_values, sizeof(return_values));
+	memcpy(msg->out + sizeof(return_values), &desc, sizeof(desc));
+	msg->out_size_out = sizeof(return_values) + sizeof(struct scmi_sensor_desc);
+}
+
+static void scmi_sensor_config_get(struct scmi_msg *msg)
+{
+	const struct scmi_sensor_config_get_a2p *in_args = (void *)msg->in;
+	struct scmi_sensor_config_get_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+	unsigned int sensor_id = 0U;
+	uint32_t update_interval, state, timestamped;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	sensor_id = SPECULATION_SAFE_VALUE(in_args->sensor_id);
+
+	if (sensor_id >= plat_scmi_sensor_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	update_interval = plat_scmi_sensor_update_interval(msg->agent_id, sensor_id);
+	state = plat_scmi_sensor_state(msg->agent_id, sensor_id);
+	timestamped = plat_scmi_sensor_timestamped(msg->agent_id, sensor_id);
+	return_values.sensor_config = (update_interval << 11) | (timestamped << 1) | state;
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_sensor_reading_get(struct scmi_msg *msg)
+{
+	const struct scmi_sensor_reading_get_a2p *in_args = (void *)msg->in;
+	struct scmi_sensor_reading_get_p2a return_values = {
+		.status = SCMI_SUCCESS,
+	};
+	unsigned int sensor_id = 0U;
+	int32_t ret;
+
+	if (msg->in_size != sizeof(*in_args)) {
+		scmi_status_response(msg, SCMI_PROTOCOL_ERROR);
+		return;
+	}
+
+	sensor_id = SPECULATION_SAFE_VALUE(in_args->sensor_id);
+
+	if (sensor_id >= plat_scmi_sensor_count(msg->agent_id)) {
+		scmi_status_response(msg, SCMI_INVALID_PARAMETERS);
+		return;
+	}
+
+	ret = plat_scmi_sensor_reading_get(msg->agent_id, sensor_id,
+					  (uint32_t *)&return_values.val);
+	if (ret) {
+		scmi_status_response(msg, SCMI_HARDWARE_ERROR);
+		return;
+	}
+
+	scmi_write_response(msg, &return_values, sizeof(return_values));
+}
+
+static void scmi_sensor_list_update_intervals(struct scmi_msg *msg)
+{
+	/* TODO */
+	scmi_status_response(msg, SCMI_NOT_SUPPORTED);
+}
+
+static const scmi_msg_handler_t scmi_sensor_handler_table[SCMI_SENSOR_MAX] = {
+	[SCMI_PROTOCOL_VERSION] = report_version,
+	[SCMI_PROTOCOL_ATTRIBUTES] = report_attributes,
+	[SCMI_PROTOCOL_MESSAGE_ATTRIBUTES] = report_message_attributes,
+	[SCMI_SENSOR_DESCRIPTION_GET] = scmi_sensor_description_get,
+	[SCMI_SENSOR_CONFIG_GET] = scmi_sensor_config_get,
+	[SCMI_SENSOR_LIST_UPDATE_INTERVALS] = scmi_sensor_list_update_intervals,
+	[SCMI_SENSOR_READING_GET] = scmi_sensor_reading_get,
+};
+
+static bool message_id_is_supported(size_t message_id)
+{
+	return scmi_sensor_handler_table[message_id] != NULL;
+}
+
+scmi_msg_handler_t scmi_msg_get_sensor_handler(struct scmi_msg *msg)
+{
+	unsigned int message_id = SPECULATION_SAFE_VALUE(msg->message_id);
+
+	if (!message_id_is_supported(message_id)) {
+		VERBOSE("pd handle not found %u\n", msg->message_id);
+		return NULL;
+	}
+
+	return scmi_sensor_handler_table[message_id];
+}

--- a/drivers/scmi-msg/sensor.h
+++ b/drivers/scmi-msg/sensor.h
@@ -1,0 +1,125 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*
+ * Copyright 2023-2024 NXP
+ */
+
+#ifndef SCMI_MSG_SENSOR_H
+#define SCMI_MSG_SENSOR_H
+
+#include <stdint.h>
+
+#include <lib/utils_def.h>
+
+#define SCMI_PROTOCOL_VERSION_SENSOR	0x20000U
+
+/*
+ * Identifiers of the SCMI SENSOR Protocol commands
+ */
+enum scmi_sensor_command_id {
+	SCMI_SENSOR_DESCRIPTION_GET = 0x003,
+	SCMI_SENSOR_TRIP_POINT_NOTIFY = 0x004,
+	SCMI_SENSOR_TRIP_POINT_CONFIG = 0x005,
+	SCMI_SENSOR_READING_GET = 0x006,
+	SCMI_SENSOR_AXIS_DESCRIPTION_GET = 0x007,
+	SCMI_SENSOR_LIST_UPDATE_INTERVALS = 0x008,
+	SCMI_SENSOR_CONFIG_GET = 0x009,
+	SCMI_SENSOR_CONFIG_SET = 0x00A,
+	SCMI_SENSOR_CONTINUOUS_UPDATE_NOTIFY = 0x00B,
+	SCMI_SENSOR_MAX = 0x00C,
+};
+
+/* Protocol attributes */
+struct scmi_protocol_attributes_p2a_sensor {
+	int32_t status;
+	int16_t num_sensors;
+	uint8_t max_reqs;
+	uint8_t res;
+	uint32_t sensor_reg_low;
+	uint32_t sensor_reg_high;
+	uint32_t sensor_reg_len;
+};
+
+#define SCMI_SENSOR_NAME_LENGTH_MAX	16U
+
+struct scmi_sensor_desc {
+	uint32_t id;
+	uint32_t attr_low;
+	uint32_t attr_high;
+	uint8_t name[SCMI_SENSOR_NAME_LENGTH_MAX];
+	uint32_t power;
+	uint32_t resolution;
+	int32_t min_range_low;
+	int32_t min_range_high;
+	int32_t max_range_low;
+	int32_t max_range_high;
+};
+
+struct scmi_sensor_description_get_a2p {
+	uint32_t desc_index;
+};
+
+struct scmi_sensor_description_get_p2a {
+	int32_t status;
+	uint32_t num_sensor_flags;
+};
+
+struct scmi_sensor_config_get_a2p {
+	uint32_t sensor_id;
+};
+
+struct scmi_sensor_config_get_p2a {
+	int32_t status;
+	uint32_t sensor_config;
+};
+
+/*
+ * Sensor Reading Get
+ */
+struct scmi_sensor_reading_get_a2p {
+	uint32_t sensor_id;
+	uint32_t flags;
+};
+
+struct scmi_sensor_val {
+	uint32_t value_low;
+	uint32_t value_high;
+	uint32_t timestap_low;
+	uint32_t timestap_high;
+};
+
+struct scmi_sensor_reading_get_p2a {
+	int32_t status;
+	struct scmi_sensor_val val;
+};
+
+typedef struct {
+	uint16_t (*sensor_count)(unsigned int agent_id);
+	uint8_t (*sensor_max_request)(unsigned int agent_id);
+	uint32_t (*get_sensor_req)(unsigned int agent_id, unsigned int *addr);
+	int32_t (*sensor_reading_get)(uint32_t agent_id, uint16_t sensor_id,
+				      uint32_t *val);
+	uint32_t (*sensor_description_get)(unsigned int agent_id, uint16_t sensor_id,
+					  struct scmi_sensor_desc *desc);
+	uint32_t (*sensor_update_interval)(uint32_t agent_id, uint16_t sensor_id);
+	uint32_t (*sensor_state)(uint32_t agent_id, uint16_t sensor_id);
+	uint16_t (*sensor_timestamped)(uint32_t agent_id, uint16_t sensor_id);
+} plat_scmi_sensor_ops_t;
+
+#define REGISTER_SCMI_SENSOR_OPS(_sensor_count, _sensor_max_request, \
+				 _get_sensor_req, _sensor_reading_get, \
+				 _sensor_description_get, _sensor_update_interval, \
+				 _sensor_state, _sensor_timestamped) \
+	const plat_scmi_sensor_ops_t sensor_ops = { \
+		.sensor_count = _sensor_count, \
+		.sensor_max_request = _sensor_max_request, \
+		.get_sensor_req = _get_sensor_req, \
+		.sensor_reading_get = _sensor_reading_get, \
+		.sensor_description_get = _sensor_description_get, \
+		.sensor_update_interval = _sensor_update_interval, \
+		.sensor_state = _sensor_state, \
+		.sensor_timestamped = _sensor_timestamped, \
+	}
+
+extern const plat_scmi_sensor_ops_t sensor_ops;
+
+#endif /* SCMI_MSG_SENSOR_H */

--- a/include/drivers/scmi-msg.h
+++ b/include/drivers/scmi-msg.h
@@ -113,10 +113,12 @@ const char *plat_scmi_clock_get_name(unsigned int agent_id,
  * @scmi_id: SCMI clock ID
  * @rates: If NULL, function returns, else output rates array
  * @nb_elts: Array size of @rates.
+ * @start_idx: Start index of rates array
  * Return an SCMI compliant error code
  */
 int32_t plat_scmi_clock_rates_array(unsigned int agent_id, unsigned int scmi_id,
-				    unsigned long *rates, size_t *nb_elts);
+				    unsigned long *rates, size_t *nb_elts,
+				    uint32_t start_idx);
 
 /*
  * Get clock possible rate as range with regular steps in Hertz

--- a/include/drivers/scmi-msg.h
+++ b/include/drivers/scmi-msg.h
@@ -87,6 +87,29 @@ uint32_t plat_scmi_agent_count(void);
 const char *plat_scmi_agent_get_name(unsigned int agent_id);
 
 /*
+ * Return how many SCMI devices are supported by the platform.
+ */
+uint32_t plat_scmi_device_count(void);
+
+/*
+ * Set an agent permissions to access device
+ * @agent_id: SCMI agent ID
+ * @device_id: SCMI device ID
+ * @allow: true to grant permissions
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_device_permission(uint32_t agent_id, uint32_t device_id,
+				    bool allow);
+
+/*
+ * Reset platform resource settings that were previously configured by an agent.
+ * @agent_id: SCMI agent ID
+ * @reset_perm: reset all access permission settings of the agent
+ * Return a compliant SCMI error code
+ */
+int32_t plat_scmi_reset_agent_cfg(uint32_t agent_id, bool reset_perm);
+
+/*
  * Get the count and list of SCMI protocols (but base) supported for an agent
  *
  * @agent_id: SCMI agent ID

--- a/include/drivers/scmi-msg.h
+++ b/include/drivers/scmi-msg.h
@@ -75,6 +75,18 @@ struct scmi_msg_channel *plat_scmi_get_channel(unsigned int agent_id);
 size_t plat_scmi_protocol_count(void);
 
 /*
+ * Return how many SCMI agents are supported by the platform.
+ */
+uint32_t plat_scmi_agent_count(void);
+
+/*
+ * Return the SCMI agent name
+ * @agent_id: SCMI agent ID
+ * Return a pointer to agent name on success, NULL otherwise
+ */
+const char *plat_scmi_agent_get_name(unsigned int agent_id);
+
+/*
  * Get the count and list of SCMI protocols (but base) supported for an agent
  *
  * @agent_id: SCMI agent ID

--- a/include/drivers/scmi-msg.h
+++ b/include/drivers/scmi-msg.h
@@ -241,4 +241,12 @@ int32_t plat_scmi_rstd_autonomous(unsigned int agent_id, unsigned int scmi_id,
 int32_t plat_scmi_rstd_set_state(unsigned int agent_id, unsigned int scmi_id,
 				 bool assert_not_deassert);
 
+/*
+ * Check reset domain permissions for agent
+ * @agent_id: SCMI agent ID
+ * @domain_id: SCMI reset domain ID
+ * Return a true if allowed
+ */
+bool plat_scmi_rstd_permitted(uint32_t agent_id, uint32_t domain_id);
+
 #endif /* SCMI_MSG_H */

--- a/plat/renesas/rcar_gen4/aarch64/platform_common.c
+++ b/plat/renesas/rcar_gen4/aarch64/platform_common.c
@@ -65,6 +65,11 @@ const uint8_t version_of_renesas[VERSION_OF_RENESAS_MAXLEN]
 					RCAR_SCMI_CHANNEL_SIZE,		\
 					MT_DEVICE | MT_RW | MT_SECURE)
 
+#ifdef SCMI_SERVER_SUPPORT
+#define MAP_SCMI_MEM                                                           \
+	MAP_REGION_FLAT(RCAR_SCMI_SHMEM_BASE, RCAR_SCMI_SHMEM_SIZE,            \
+			MT_NON_CACHEABLE | MT_RW | MT_NS)
+#endif
 
 static const mmap_region_t rcar_mmap[] = {
 	MAP_SHARED_RAM,	  /* 0x46422000 - 0x46422FFF  Shared ram area       */
@@ -74,6 +79,9 @@ static const mmap_region_t rcar_mmap[] = {
 	MAP_SRAM_DATA_STACK, /* 0xE6344000 - 0xE6344FFF  System RAM data & stack area */
 	MAP_SCMI_CHANNEL, /* 0xE6341000 - 0xE6341FFF  SCMI channel area     */
 	MAP_DEVICE_RCAR2, /* 0xE6370000 - 0xFFFFFFFF  SoC registers area 2  */
+#ifdef SCMI_SERVER_SUPPORT
+	MAP_SCMI_MEM,
+#endif
 	{0}
 };
 

--- a/plat/renesas/rcar_gen4/bl31_plat_setup.c
+++ b/plat/renesas/rcar_gen4/bl31_plat_setup.c
@@ -14,6 +14,7 @@
 #include <common/debug.h>
 #include <drivers/arm/cci.h>
 #include <drivers/console.h>
+#include <drivers/generic_delay_timer.h>
 #include <lib/mmio.h>
 #include <plat/common/platform.h>
 
@@ -92,6 +93,11 @@ void bl31_platform_setup(void)
 	plat_rcar_scmi_setup();
 	rcar_pwrc_setup();
 	rcar_ptp_setup();
+
+	/* Enable arch timer */
+	generic_delay_timer_init();
+
+	rcar_init_scmi_server();
 }
 
 const spd_pm_ops_t rcar_pm = {

--- a/plat/renesas/rcar_gen4/include/rcar_def.h
+++ b/plat/renesas/rcar_gen4/include/rcar_def.h
@@ -45,7 +45,7 @@
  * The RCAR_MAX_MMAP_REGIONS depends on the number of entries in rcar_mmap[]
  * defined for each BL stage in platform_common.c.
  */
-#define RCAR_MMAP_ENTRIES		(8)
+#define RCAR_MMAP_ENTRIES		(9)
 /* BL31 */
 #define RCAR_CRASH_STACK		RCAR_BL31_CRASH_BASE
 

--- a/plat/renesas/rcar_gen4/include/rcar_private.h
+++ b/plat/renesas/rcar_gen4/include/rcar_private.h
@@ -119,4 +119,10 @@ static inline const plat_psci_ops_t *plat_rcar_psci_override_pm_ops(plat_psci_op
 
 int32_t rcar_cluster_pos_by_mpidr(u_register_t mpidr);
 
+#ifdef SCMI_SERVER_SUPPORT
+void rcar_init_scmi_server(void);
+#else
+static inline void rcar_init_scmi_server(void) { }
+#endif /* SCMI_SERVER_SUPPORT */
+
 #endif /* RCAR_PRIVATE_H */

--- a/plat/renesas/rcar_gen4/include/rcar_smc.h
+++ b/plat/renesas/rcar_gen4/include/rcar_smc.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef PLAT_INCLUDE_RCAR_SMC_H_
+#define PLAT_INCLUDE_RCAR_SMC_H_
+
+#include <lib/smccc.h>
+
+/*
+ * Process scmi message pending in the SCMI message
+ * shared memory buffer.
+ */
+#define RCAR_SIP_SMC_SCMI 0x82000002
+
+#endif /* PLAT_INCLUDE_RCAR_SMC_H_ */

--- a/plat/renesas/rcar_gen4/platform.mk
+++ b/plat/renesas/rcar_gen4/platform.mk
@@ -17,6 +17,9 @@ CRASH_REPORTING			:= 1
 HANDLE_EA_EL3_FIRST		:= 1
 ENABLE_STACK_PROTECTOR	:= strong
 
+# Enable SCMI server support
+SCMI_SERVER_SUPPORT		?= 1
+
 # Process SET_SCMI_PARAM flag
 # 0:Disable(default), 1:Enable
 ifndef SET_SCMI_PARAM
@@ -30,6 +33,24 @@ else
     else
         $(error "Error:SET_SCMI_PARAM=${SET_SCMI_PARAM} is not supported.")
     endif
+endif
+
+ifeq ($(SCMI_SERVER_SUPPORT), 1)
+$(eval $(call add_define,SCMI_SERVER_SUPPORT))
+
+#SCMI Server sources
+BL31_SOURCES		+= drivers/scmi-msg/base.c			\
+				drivers/scmi-msg/entry.c		\
+				drivers/scmi-msg/smt.c			\
+				plat/renesas/rcar_gen4/scmi/scmi.c		\
+				plat/renesas/rcar_gen4/rcar_svc_setup.c
+
+RCAR_SCMI_SHMEM_BASE := 0x47ff0000
+RCAR_SCMI_SHMEM_SIZE := 0x10000
+RCAR_SCMI_NUM_AGENTS ?= 8
+$(eval $(call add_define,RCAR_SCMI_SHMEM_BASE))
+$(eval $(call add_define,RCAR_SCMI_SHMEM_SIZE))
+$(eval $(call add_define_val,SCMI_NUM_AGENTS,${RCAR_SCMI_NUM_AGENTS}))
 endif
 
 ifndef PTP_NONSECURE_ACCESS
@@ -141,7 +162,9 @@ BL31_SOURCES	+=	${RCAR_GIC_SOURCES}				\
 			drivers/renesas/rcar_gen4/scif/scif.c		\
 			drivers/renesas/rcar_gen4/scif/scif_helpers.S	\
 			drivers/renesas/rcar_gen4/mssr/mssr.c		\
-			drivers/arm/cci/cci.c
+			drivers/arm/cci/cci.c \
+			drivers/delay_timer/delay_timer.c		\
+			drivers/delay_timer/generic_delay_timer.c
 
 ifeq (${SET_SCMI_PARAM},1)
 BL31_SOURCES	+=	${SCMI_DRIVER_SOURES}				\

--- a/plat/renesas/rcar_gen4/rcar_svc_setup.c
+++ b/plat/renesas/rcar_gen4/rcar_svc_setup.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <common/debug.h>
+#include <common/runtime_svc.h>
+#include <drivers/scmi-msg.h>
+
+#include <rcar_smc.h>
+
+/* Setup Standard Services */
+static int32_t rcar_svc_setup(void)
+{
+	return 0;
+}
+
+/*
+ * Top-level Standard Service SMC handler.
+ */
+static uintptr_t rcar_svc_smc_handler(uint32_t smc_fid, u_register_t x1,
+				      u_register_t x2, u_register_t x3,
+				      u_register_t x4, void *cookie,
+				      void *handle, u_register_t flags)
+{
+	uint32_t ret1 = 0U;
+
+	switch (smc_fid) {
+	case RCAR_SIP_SMC_SCMI:
+		scmi_smt_fastcall_smc_entry(0);
+		break;
+	case RCAR_SIP_SMC_SCMI + 1:
+		scmi_smt_fastcall_smc_entry(1);
+		break;
+	case RCAR_SIP_SMC_SCMI + 2:
+		scmi_smt_fastcall_smc_entry(2);
+		break;
+	case RCAR_SIP_SMC_SCMI + 3:
+		scmi_smt_fastcall_smc_entry(3);
+		break;
+	case RCAR_SIP_SMC_SCMI + 4:
+		scmi_smt_fastcall_smc_entry(4);
+		break;
+	case RCAR_SIP_SMC_SCMI + 5:
+		scmi_smt_fastcall_smc_entry(5);
+		break;
+	case RCAR_SIP_SMC_SCMI + 6:
+		scmi_smt_fastcall_smc_entry(6);
+		break;
+	case RCAR_SIP_SMC_SCMI + 7:
+		scmi_smt_fastcall_smc_entry(7);
+		break;
+
+	default:
+		WARN("Unknown RCAR Service Call: 0x%x\n", smc_fid);
+		ret1 = SMC_UNK;
+		break;
+	}
+
+	SMC_RET1(handle, ret1);
+}
+
+/* Register Standard Service Calls as runtime service */
+DECLARE_RT_SVC(rcar_sip_svc,
+	       OEN_SIP_START,
+	       OEN_SIP_END,
+	       SMC_TYPE_FAST,
+	       rcar_svc_setup,
+	       rcar_svc_smc_handler
+);

--- a/plat/renesas/rcar_gen4/scmi/scmi.c
+++ b/plat/renesas/rcar_gen4/scmi/scmi.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 EPAM Systems
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <assert.h>
+#include <stdint.h>
+
+
+#include <drivers/scmi-msg.h>
+#include <drivers/scmi.h>
+#include <lib/xlat_tables/xlat_tables_defs.h>
+
+#include <platform_def.h>
+
+#define RCAR_SHM_N_BASE(n)	(RCAR_SCMI_SHMEM_BASE + n * PAGE_SIZE_4KB)
+
+static struct scmi_msg_channel scmi_channel[SCMI_NUM_AGENTS] = {
+	[0] = {
+		.shm_addr = RCAR_SHM_N_BASE(0),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-0",
+	},
+	[1] = {
+		.shm_addr = RCAR_SHM_N_BASE(1),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-1",
+	},
+	[2] = {
+		.shm_addr = RCAR_SHM_N_BASE(2),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-2",
+	},
+	[3] = {
+		.shm_addr = RCAR_SHM_N_BASE(3),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-3",
+	},
+	[4] = {
+		.shm_addr = RCAR_SHM_N_BASE(4),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-4",
+	},
+	[5] = {
+		.shm_addr = RCAR_SHM_N_BASE(5),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-5",
+	},
+	[6] = {
+		.shm_addr = RCAR_SHM_N_BASE(6),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-6",
+	},
+	[7] = {
+		.shm_addr = RCAR_SHM_N_BASE(7),
+		.shm_size = SMT_BUF_SLOT_SIZE,
+		.agent_name = "agent-7",
+	},
+};
+
+struct scmi_msg_channel *plat_scmi_get_channel(unsigned int agent_id)
+{
+	assert(agent_id < ARRAY_SIZE(scmi_channel));
+
+	return &scmi_channel[agent_id];
+}
+
+const char *plat_scmi_agent_get_name(unsigned int agent_id)
+{
+	assert(agent_id < ARRAY_SIZE(scmi_channel));
+
+	return scmi_channel[agent_id].agent_name;
+}
+
+static const char vendor[] = "EPAM";
+static const char sub_vendor[] = "";
+
+const char *plat_scmi_vendor_name(void)
+{
+	return vendor;
+}
+
+const char *plat_scmi_sub_vendor_name(void)
+{
+	return sub_vendor;
+}
+
+static const uint8_t plat_protocol_list[] = {
+	0U /* Null termination */
+};
+
+size_t plat_scmi_protocol_count(void)
+{
+	return ARRAY_SIZE(plat_protocol_list) - 1U;
+}
+
+uint32_t plat_scmi_agent_count(void)
+{
+	return SCMI_NUM_AGENTS;
+}
+
+const uint8_t *plat_scmi_protocol_list(unsigned int agent_id __unused)
+{
+	return plat_protocol_list;
+}
+
+void rcar_init_scmi_server(void)
+{
+	size_t i;
+
+	for (i = 0U; i < ARRAY_SIZE(scmi_channel); i++) {
+		scmi_smt_init_agent_channel(&scmi_channel[i]);
+	}
+}

--- a/plat/st/stm32mp1/stm32mp1_scmi.c
+++ b/plat/st/stm32mp1/stm32mp1_scmi.c
@@ -260,7 +260,8 @@ const char *plat_scmi_clock_get_name(unsigned int agent_id,
 }
 
 int32_t plat_scmi_clock_rates_array(unsigned int agent_id, unsigned int scmi_id,
-				    unsigned long *array, size_t *nb_elts)
+				    unsigned long *array, size_t *nb_elts,
+				    uint32_t start_idx)
 {
 	struct stm32_scmi_clk *clock = find_clock(agent_id, scmi_id);
 
@@ -270,6 +271,10 @@ int32_t plat_scmi_clock_rates_array(unsigned int agent_id, unsigned int scmi_id,
 
 	if (!stm32mp_nsec_can_access_clock(clock->clock_id)) {
 		return SCMI_DENIED;
+	}
+
+	if (start_idx > 0) {
+		return SCMI_OUT_OF_RANGE;
 	}
 
 	if (array == NULL) {


### PR DESCRIPTION
Add basic SCMI server support for Renesas rcar gen4 V4H platform.

The SCMI is controlled by option SCMI_SERVER_SUPPORT and enabled by default.
    
    SCMI build options:
    - RCAR_SCMI_SHMEM_BASE the SCMI shmem base address. Now set to 0x47ff0000
    - SCMI_NUM_AGENTS number of Agents (default 8)
    - RCAR_SIP_SMC_SCMI == 0x82000002

Linux kernel:
https://github.com/GrygiriiS/linux/tree/gen4-v5.10.147-rcar-5.2.0.rc17_scmi_pd

Linux kernel log:
```
[    0.000000] Linux version 5.10.147+ (grygorii@epuakyiw0a98) (aarch64-zephyr-elf-gcc (Zephyr SDK 0.16.3) 12.2.0, GNU ld (Zephyr SDK 0.16.3) 2.38) #86 SMP PREEMPT Fri Oct 4 18:51:49 EEST 2024
...
[    0.109686] arm-scmi firmware:scmi: SCMI Notifications - Core Enabled.
[    0.109734] arm-scmi firmware:scmi: SCMI Protocol v2.0 'EPAM:' Firmware version 0x0
[    0.109800] arm-scmi firmware:scmi: SCMI protocol 17 not implemented
[    0.109805] arm-scmi firmware:scmi: SCMI protocol 22 not implemented
```

Linux CFG:
```
+CONFIG_ARM_SCMI_PROTOCOL=y
+CONFIG_COMMON_CLK_SCMI=y
+CONFIG_SENSORS_ARM_SCMI=y
+CONFIG_IIO_SCMI=y
```

Linux DT:
```
+       scmi_shm_0: sram@47ff0000 {
+               compatible = "arm,scmi-shmem";
+               reg = <0x0 0x47ff0000 0x0 0x1000>;
+       };
+
+       firmware {
+               scmi: scmi {
+                       compatible = "arm,scmi-smc";
+                       arm,smc-id = <0x82000002>;
+                       #address-cells = <1>;
+                       #size-cells = <0>;
+                       #access-controller-cells = <1>;
+                       shmem = <&scmi_shm_0>;
+
+                       scmi_pd: protocol@11 {
+                               reg = <0x11>;
+                               #power-domain-cells = <1>;
+                       };
+
+                       scmi_reset: protocol@16 {
+                               reg = <0x16>;
+                               #reset-cells = <1>;
+                       };
+               };
+       };
```
